### PR TITLE
Update python-package-deploy.yml

### DIFF
--- a/.github/workflows/python-package-deploy.yml
+++ b/.github/workflows/python-package-deploy.yml
@@ -4,8 +4,9 @@
 name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
 
 on:
-  push:
-    branches: [main, develop]
+  push:    
+    tags:
+      - v*
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
@@ -34,8 +35,7 @@ jobs:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
         skip_existing: true
-    - name: Publish distribution 📦 to PyPI
-      if: startsWith(github.ref, 'refs/tags')
+    - name: Publish distribution 📦 to PyPI      
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
The github action was not picking up the condition for the publish to pypi job (only on pushing tags).

The job can now be triggered when adding a tag that starts with "v", like "v0.1.0"