### PR TITLE
Allow longer `internalVersion` numbers

### DIFF
--- a/pyecospold/schemas/v1/EcoSpold01MetaInformation.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01MetaInformation.xsd
@@ -137,7 +137,7 @@ All Rights Reserved.
 			</xsd:annotation>
 			<xsd:simpleType>
 				<xsd:restriction base="xsd:float">
-					<xsd:pattern value="\d{1,2}\.\d{1,2}"></xsd:pattern>
+					<xsd:pattern value="\d{1,3}\.\d{1,2}"></xsd:pattern>
 				</xsd:restriction>
 			</xsd:simpleType>
 		</xsd:attribute>


### PR DESCRIPTION
Fixes a problem import version 2.2 of the ecoinvent database.