### PR TITLE
Allow longer `internalVersion` numbers

### DIFF
--- a/pyecospold/schemas/v1/EcoSpold01MetaInformation.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01MetaInformation.xsd
@@ -128,7 +128,7 @@ All Rights Reserved.
 				<xsd:appinfo>
 					<spoldID>207</spoldID>
 					<type>Number (Decimal)</type>
-					<size>2.2</size>
+					<size>3.2</size>
 					<options></options>
 					<multipleOccurences>
 					No</multipleOccurences>


### PR DESCRIPTION
Ecoinvent 2.2 uses `internalVersion` values like `115.20`. This breaks the XSD, but at the same point it is released by the organization which created the XSD file, and is the most used implementation of `ecospold` version one. So at least to me the most reasonable option is to adapt the XSD to the real world.