### PR TITLE
Version 1.1 of ecospold1 schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ You can install _pyecospold_ via [pip] from [PyPI]:
 $ pip install pyecospold
 ```
 
+## ecospold1 version 1.1
+
+This library includes a new version of the schema definitions for ecospold1. Version 1.1 includes the following changes:
+
+* Changed the length restriction on `referenceFunction.name` to 255
+* Changed the length restriction on `referenceFunction.synonym` to 255
+* Changed the length restriction on `category` and `subCategory` to 255
+* Changed the length restriction on `representativeness.productionVolume` to 32.000
+* Made `telephone` optional
+
+These changes were based on how this schema was being used by LCA software.
+
 ## Usage
 
 ```python

--- a/pyecospold/model_v1.py
+++ b/pyecospold/model_v1.py
@@ -1034,7 +1034,17 @@ class DataGeneratorAndPublication(etree.ElementBase):
     of the database quality networks (see also 'qualityNetwork') are characterised
     and identified. 'countryCode' is required additionally. Only required and
     allowed if access to the dataset is restricted to a particular institute within
-    the ecoinvent quality network."""
+    the ecoinvent quality network.
+
+    Here are the codes used in ecoinvent release 2.2:
+
+        {'ART', 'B+H', 'BAUCHEM', 'CARBOTE', 'DOKA', 'ECN', 'EMPA', 'EMPA-SG', 'ENERS',
+        'EPFL', 'ESU', 'ETH S+U', 'ETH-UNS', 'HEIG-VD', 'INFRAS', 'LCS', 'OEKOSCI',
+        'PRIVAT', 'PSI', 'SBB', 'SCHLEIS', 'U+E', 'UU'}
+
+    The length 7 restriction is bizarre; just truncate and move on with your life.
+
+    """
 
     countryCode = DataHelper.create_attribute_v1("countryCode", str)
     """str: 2 letter ISO-country codes are used to indicate the country where

--- a/pyecospold/schemas/v1/EcoInventCategories.xsd
+++ b/pyecospold/schemas/v1/EcoInventCategories.xsd
@@ -16,7 +16,7 @@ All Rights Reserved.
 <xsd:schema targetNamespace="http://www.EcoInvent.org/Categories"
 	xmlns="http://www.EcoInvent.org/Categories" xmlns:ec="http://www.EcoInvent.org/Categories"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
-	attributeFormDefault="unqualified" blockDefault="restriction" version="1.0">
+	attributeFormDefault="unqualified" blockDefault="restriction" version="1.1">
 	<xsd:include schemaLocation="EcoSpold01DataTypes.xsd" />
 
 	<xsd:complexType name="TSubCategory">

--- a/pyecospold/schemas/v1/EcoInventCompanyCodes.xsd
+++ b/pyecospold/schemas/v1/EcoInventCompanyCodes.xsd
@@ -16,7 +16,7 @@ All Rights Reserved.
 <xsd:schema targetNamespace="http://www.EcoInvent.org/CompanyCodes"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.EcoInvent.org/CompanyCodes"
 	elementFormDefault="qualified" attributeFormDefault="unqualified" blockDefault="restriction"
-	version="1.0">
+	version="1.1">
 	<xsd:include schemaLocation="EcoSpold01DataTypes.xsd" />
 
 	<xsd:element name="companyCodes">

--- a/pyecospold/schemas/v1/EcoInventRegionalCodes.xsd
+++ b/pyecospold/schemas/v1/EcoInventRegionalCodes.xsd
@@ -16,7 +16,7 @@ All Rights Reserved.
 <xsd:schema targetNamespace="http://www.EcoInvent.org/RegionalCodes"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.EcoInvent.org/RegionalCodes"
 	elementFormDefault="qualified" attributeFormDefault="unqualified" blockDefault="restriction"
-	version="1.0">
+	version="1.1">
 	<xsd:simpleType name="regionalCode">
 		<xsd:annotation>
 			<xsd:documentation>7 letter code based on the ISO country codes and enlarged by regional

--- a/pyecospold/schemas/v1/EcoInventUnits.xsd
+++ b/pyecospold/schemas/v1/EcoInventUnits.xsd
@@ -15,7 +15,7 @@ All Rights Reserved.
 -->
 <xsd:schema targetNamespace="http://www.EcoInvent.org/Units" xmlns="http://www.EcoInvent.org/Units"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
-	attributeFormDefault="unqualified" version="1.0">
+	attributeFormDefault="unqualified" version="1.1">
 	<xsd:include schemaLocation="EcoSpold01DataTypes.xsd" />
 
 	<xsd:element name="units">

--- a/pyecospold/schemas/v1/EcoSpold01DataTypes.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01DataTypes.xsd
@@ -645,10 +645,10 @@ All Rights Reserved.
 	</xsd:simpleType>
 	<xsd:simpleType name="TCategoryName">
 		<xsd:annotation>
-			<xsd:documentation>40 letter string.</xsd:documentation>
+			<xsd:documentation>255 letter string.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:string">
-			<xsd:maxLength value="40" fixed="false" />
+			<xsd:maxLength value="255" fixed="false" />
 			<xsd:minLength value="0" />
 		</xsd:restriction>
 	</xsd:simpleType>

--- a/pyecospold/schemas/v1/EcoSpold01DataTypes.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01DataTypes.xsd
@@ -14,7 +14,7 @@ Portions created by the ecoinvent Centre and ifu Hamburg GmbH are Copyright (C) 
 All Rights Reserved.
 -->
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
-	attributeFormDefault="unqualified" version="1.0">
+	attributeFormDefault="unqualified" version="1.1">
 	<xsd:simpleType name="TIndexNumber">
 		<xsd:annotation>
 			<xsd:documentation>Unique identifier. Format: Integer (32-bit) greater then zero</xsd:documentation>

--- a/pyecospold/schemas/v1/EcoSpold01DataTypes.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01DataTypes.xsd
@@ -168,7 +168,7 @@ All Rights Reserved.
 				<xsd:documentation>Identifies the person together with 'name' (#5802).</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attribute name="telephone" type="TString40" use="required">
+		<xsd:attribute name="telephone" type="TString40" use="optional">
 			<xsd:annotation>
 				<xsd:appinfo>
 					<spoldID>5804</spoldID>

--- a/pyecospold/schemas/v1/EcoSpold01Dataset.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01Dataset.xsd
@@ -14,7 +14,7 @@ Portions created by the ecoinvent Centre and ifu Hamburg GmbH are Copyright (C) 
 All Rights Reserved.
 -->
 <xsd:schema targetNamespace="http://www.EcoInvent.org/EcoSpold01" elementFormDefault="qualified"
-	attributeFormDefault="unqualified" version="1.0" xmlns:es="http://www.EcoInvent.org/EcoSpold01"
+	attributeFormDefault="unqualified" version="1.1" xmlns:es="http://www.EcoInvent.org/EcoSpold01"
 	xmlns="http://www.EcoInvent.org/EcoSpold01" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 	<xsd:annotation>
 		<xsd:appinfo>

--- a/pyecospold/schemas/v1/EcoSpold01ElementaryDataset.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01ElementaryDataset.xsd
@@ -14,7 +14,7 @@ Portions created by the ecoinvent Centre and ifu Hamburg GmbH are Copyright (C) 
 All Rights Reserved.
 -->
 <xsd:schema targetNamespace="http://www.EcoInvent.org/EcoSpold01Elementary"
-	elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0"
+	elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1"
 	xmlns:es="http://www.EcoInvent.org/EcoSpold01Elementary"
 	xmlns="http://www.EcoInvent.org/EcoSpold01Elementary"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema">

--- a/pyecospold/schemas/v1/EcoSpold01FlowData.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01FlowData.xsd
@@ -100,7 +100,7 @@ All Rights Reserved.
 				<xsd:appinfo>
 					<spoldID>3506</spoldID>
 					<type>Text</type>
-					<size>40</size>
+					<size>255</size>
 					<options></options>
 					<multipleOccurences>
 					Yes</multipleOccurences>
@@ -116,7 +116,7 @@ All Rights Reserved.
 				<xsd:appinfo>
 					<spoldID>3507</spoldID>
 					<type>Text</type>
-					<size>40</size>
+					<size>255</size>
 					<options></options>
 					<multipleOccurences>
 					Yes</multipleOccurences>
@@ -132,7 +132,7 @@ All Rights Reserved.
 				<xsd:appinfo>
 					<spoldID>3509</spoldID>
 					<type>Text</type>
-					<size>40</size>
+					<size>255</size>
 					<options></options>
 					<multipleOccurences>
 					Yes</multipleOccurences>
@@ -147,7 +147,7 @@ All Rights Reserved.
 				<xsd:appinfo>
 					<spoldID>3510</spoldID>
 					<type>Text</type>
-					<size>40</size>
+					<size>255</size>
 					<options></options>
 					<multipleOccurences>
 					Yes</multipleOccurences>

--- a/pyecospold/schemas/v1/EcoSpold01FlowData.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01FlowData.xsd
@@ -13,7 +13,7 @@ Centre, Switzerland (Swiss Centre for Life Cycle Inventories) and ifu Hamburg Gm
 Portions created by the ecoinvent Centre and ifu Hamburg GmbH are Copyright (C) ecoinvent Centre.
 All Rights Reserved.
 -->
-<xsd:schema elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0"
+<xsd:schema elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 	<xsd:include schemaLocation="EcoSpold01DataTypes.xsd"></xsd:include>
 	<xsd:complexType name="TExchange">

--- a/pyecospold/schemas/v1/EcoSpold01FlowData.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01FlowData.xsd
@@ -179,12 +179,12 @@ All Rights Reserved.
 				</xsd:restriction>
 			</xsd:simpleType>
 		</xsd:attribute>
-		<xsd:attribute name="name" type="TString80" use="required">
+		<xsd:attribute name="name" type="TString255" use="required">
 			<xsd:annotation>
 				<xsd:appinfo>
 					<spoldID>3702</spoldID>
 					<type>Text</type>
-					<size>80</size>
+					<size>255</size>
 					<options></options>
 					<multipleOccurences>
 					Yes</multipleOccurences>

--- a/pyecospold/schemas/v1/EcoSpold01ImpactDataset.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01ImpactDataset.xsd
@@ -14,7 +14,7 @@ Portions created by the ecoinvent Centre and ifu Hamburg GmbH are Copyright (C) 
 All Rights Reserved.
 -->
 <xsd:schema targetNamespace="http://www.EcoInvent.org/EcoSpold01Impact"
-	elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0"
+	elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.EcoInvent.org/EcoSpold01Impact"
 	xmlns:es="http://www.EcoInvent.org/EcoSpold01Impact">
 	<xsd:annotation>

--- a/pyecospold/schemas/v1/EcoSpold01MetaInformation.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01MetaInformation.xsd
@@ -457,12 +457,12 @@ All Rights Reserved.
 				</xsd:restriction>
 			</xsd:simpleType>
 		</xsd:attribute>
-		<xsd:attribute name="productionVolume" type="TString80" use="optional">
+		<xsd:attribute name="productionVolume" type="TString32000" use="optional">
 			<xsd:annotation>
 				<xsd:appinfo>
 					<spoldID>724</spoldID>
 					<type>Text</type>
-					<size>80</size>
+					<size>320000</size>
 					<options></options>
 					<multipleOccurences>
 					No</multipleOccurences>

--- a/pyecospold/schemas/v1/EcoSpold01MetaInformation.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01MetaInformation.xsd
@@ -1069,12 +1069,12 @@ All Rights Reserved.
 					impact categories.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attribute name="name" type="TString80" use="required">
+		<xsd:attribute name="name" type="TString255" use="required">
 			<xsd:annotation>
 				<xsd:appinfo>
 					<spoldID>401</spoldID>
 					<type>Text</type>
-					<size>80</size>
+					<size>255</size>
 					<options></options>
 					<multipleOccurences>
 					No</multipleOccurences>
@@ -1099,12 +1099,12 @@ All Rights Reserved.
 				<xsd:documentation>English is the default language in the ecoinvent quality network.</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attribute name="localName" type="TString80" use="required">
+		<xsd:attribute name="localName" type="TString255" use="required">
 			<xsd:annotation>
 				<xsd:appinfo>
 					<spoldID>490</spoldID>
 					<type>Text</type>
-					<size>80</size>
+					<size>255</size>
 					<options></options>
 					<multipleOccurences>
 					No</multipleOccurences>

--- a/pyecospold/schemas/v1/EcoSpold01MetaInformation.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01MetaInformation.xsd
@@ -1033,12 +1033,12 @@ All Rights Reserved.
 				(english and german), unit, classification (category, subCategory), etc..</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence minOccurs="0" maxOccurs="unbounded">
-			<xsd:element name="synonym" type="TString80">
+			<xsd:element name="synonym" type="TString255">
 				<xsd:annotation>
 					<xsd:appinfo>
 						<spoldID>491</spoldID>
 						<type>Text</type>
-						<size>80</size>
+						<size>255</size>
 						<options></options>
 						<multipleOccurences>
 						Yes</multipleOccurences>

--- a/pyecospold/schemas/v1/EcoSpold01MetaInformation.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01MetaInformation.xsd
@@ -1179,7 +1179,7 @@ All Rights Reserved.
 				<xsd:appinfo>
 					<spoldID>495</spoldID>
 					<type>Text</type>
-					<size>40</size>
+					<size>255</size>
 					<options></options>
 					<multipleOccurences>
 					No</multipleOccurences>
@@ -1198,7 +1198,7 @@ All Rights Reserved.
 				<xsd:appinfo>
 					<spoldID>496</spoldID>
 					<type>Text</type>
-					<size>40</size>
+					<size>255</size>
 					<options></options>
 					<multipleOccurences>
 					No</multipleOccurences>
@@ -1217,7 +1217,7 @@ All Rights Reserved.
 				<xsd:appinfo>
 					<spoldID>497</spoldID>
 					<type>Text</type>
-					<size>40</size>
+					<size>255</size>
 					<options></options>
 					<multipleOccurences>
 					No</multipleOccurences>
@@ -1232,7 +1232,7 @@ All Rights Reserved.
 				<xsd:appinfo>
 					<spoldID>498</spoldID>
 					<type>Text</type>
-					<size>40</size>
+					<size>255</size>
 					<options></options>
 					<multipleOccurences>
 					No</multipleOccurences>

--- a/pyecospold/schemas/v1/EcoSpold01MetaInformation.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01MetaInformation.xsd
@@ -13,7 +13,7 @@ Centre, Switzerland (Swiss Centre for Life Cycle Inventories) and ifu Hamburg Gm
 Portions created by the ecoinvent Centre and ifu Hamburg GmbH are Copyright (C) ecoinvent Centre.
 All Rights Reserved.
 -->
-<xsd:schema elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0"
+<xsd:schema elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 	<xsd:include schemaLocation="EcoSpold01DataTypes.xsd"></xsd:include>
 	<xsd:complexType name="TDataSetInformation">


### PR DESCRIPTION
Based on how this schema is being used, make the following changes:

* Changed the length restriction on `referenceFunction.name` to 255
* Changed the length restriction on `referenceFunction.synonym` to 255
* Changed the length restriction on `category` and `subCategory` to 255
* Changed the length restriction on `representativeness.productionVolume` to 32.000
* Made `telephone` optional