### PR TITLE
Allow 12-digit CAS numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ You can install _pyecospold_ via [pip] from [PyPI]:
 $ pip install pyecospold
 ```
 
-## ecospold1 version 1.1
+## ecospold1 Schema Updates
+
+### 1.1
 
 This library includes a new version of the schema definitions for ecospold1. Version 1.1 includes the following changes:
 
@@ -38,6 +40,14 @@ This library includes a new version of the schema definitions for ecospold1. Ver
 * Made `telephone` optional
 
 These changes were based on how this schema was being used by LCA software.
+
+### 1.2
+
+Corrected the handling of CAS numbers based on [the official documentation](https://www.cas.org/support/documentation/chemical-substances/checkdig):
+
+* A fixed size isn't required, zero-padding is optional and in any case is not used consistently by LCA software
+* Maximum length is 12, not 11
+* The first element has a minimum size of 2 digits, not 1
 
 ## Usage
 

--- a/pyecospold/schemas/v1/EcoInventCategories.xsd
+++ b/pyecospold/schemas/v1/EcoInventCategories.xsd
@@ -16,7 +16,7 @@ All Rights Reserved.
 <xsd:schema targetNamespace="http://www.EcoInvent.org/Categories"
 	xmlns="http://www.EcoInvent.org/Categories" xmlns:ec="http://www.EcoInvent.org/Categories"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
-	attributeFormDefault="unqualified" blockDefault="restriction" version="1.1">
+	attributeFormDefault="unqualified" blockDefault="restriction" version="1.2">
 	<xsd:include schemaLocation="EcoSpold01DataTypes.xsd" />
 
 	<xsd:complexType name="TSubCategory">

--- a/pyecospold/schemas/v1/EcoInventCompanyCodes.xsd
+++ b/pyecospold/schemas/v1/EcoInventCompanyCodes.xsd
@@ -16,7 +16,7 @@ All Rights Reserved.
 <xsd:schema targetNamespace="http://www.EcoInvent.org/CompanyCodes"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.EcoInvent.org/CompanyCodes"
 	elementFormDefault="qualified" attributeFormDefault="unqualified" blockDefault="restriction"
-	version="1.1">
+	version="1.2">
 	<xsd:include schemaLocation="EcoSpold01DataTypes.xsd" />
 
 	<xsd:element name="companyCodes">

--- a/pyecospold/schemas/v1/EcoInventRegionalCodes.xsd
+++ b/pyecospold/schemas/v1/EcoInventRegionalCodes.xsd
@@ -16,7 +16,7 @@ All Rights Reserved.
 <xsd:schema targetNamespace="http://www.EcoInvent.org/RegionalCodes"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.EcoInvent.org/RegionalCodes"
 	elementFormDefault="qualified" attributeFormDefault="unqualified" blockDefault="restriction"
-	version="1.1">
+	version="1.2">
 	<xsd:simpleType name="regionalCode">
 		<xsd:annotation>
 			<xsd:documentation>7 letter code based on the ISO country codes and enlarged by regional

--- a/pyecospold/schemas/v1/EcoInventUnits.xsd
+++ b/pyecospold/schemas/v1/EcoInventUnits.xsd
@@ -15,7 +15,7 @@ All Rights Reserved.
 -->
 <xsd:schema targetNamespace="http://www.EcoInvent.org/Units" xmlns="http://www.EcoInvent.org/Units"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
-	attributeFormDefault="unqualified" version="1.1">
+	attributeFormDefault="unqualified" version="1.2">
 	<xsd:include schemaLocation="EcoSpold01DataTypes.xsd" />
 
 	<xsd:element name="units">

--- a/pyecospold/schemas/v1/EcoSpold01DataTypes.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01DataTypes.xsd
@@ -14,7 +14,7 @@ Portions created by the ecoinvent Centre and ifu Hamburg GmbH are Copyright (C) 
 All Rights Reserved.
 -->
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
-	attributeFormDefault="unqualified" version="1.1">
+	attributeFormDefault="unqualified" version="1.2">
 	<xsd:simpleType name="TIndexNumber">
 		<xsd:annotation>
 			<xsd:documentation>Unique identifier. Format: Integer (32-bit) greater then zero</xsd:documentation>

--- a/pyecospold/schemas/v1/EcoSpold01Dataset.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01Dataset.xsd
@@ -14,7 +14,7 @@ Portions created by the ecoinvent Centre and ifu Hamburg GmbH are Copyright (C) 
 All Rights Reserved.
 -->
 <xsd:schema targetNamespace="http://www.EcoInvent.org/EcoSpold01" elementFormDefault="qualified"
-	attributeFormDefault="unqualified" version="1.1" xmlns:es="http://www.EcoInvent.org/EcoSpold01"
+	attributeFormDefault="unqualified" version="1.2" xmlns:es="http://www.EcoInvent.org/EcoSpold01"
 	xmlns="http://www.EcoInvent.org/EcoSpold01" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 	<xsd:annotation>
 		<xsd:appinfo>

--- a/pyecospold/schemas/v1/EcoSpold01ElementaryDataset.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01ElementaryDataset.xsd
@@ -14,7 +14,7 @@ Portions created by the ecoinvent Centre and ifu Hamburg GmbH are Copyright (C) 
 All Rights Reserved.
 -->
 <xsd:schema targetNamespace="http://www.EcoInvent.org/EcoSpold01Elementary"
-	elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1"
+	elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.2"
 	xmlns:es="http://www.EcoInvent.org/EcoSpold01Elementary"
 	xmlns="http://www.EcoInvent.org/EcoSpold01Elementary"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema">

--- a/pyecospold/schemas/v1/EcoSpold01FlowData.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01FlowData.xsd
@@ -13,7 +13,7 @@ Centre, Switzerland (Swiss Centre for Life Cycle Inventories) and ifu Hamburg Gm
 Portions created by the ecoinvent Centre and ifu Hamburg GmbH are Copyright (C) ecoinvent Centre.
 All Rights Reserved.
 -->
-<xsd:schema elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1"
+<xsd:schema elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.2"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 	<xsd:include schemaLocation="EcoSpold01DataTypes.xsd"></xsd:include>
 	<xsd:complexType name="TExchange">
@@ -162,20 +162,19 @@ All Rights Reserved.
 				<xsd:appinfo>
 					<spoldID>3701</spoldID>
 					<type>String</type>
-					<size>11</size>
 					<options></options>
 					<multipleOccurences>
 					Yes</multipleOccurences>
 					<valueRequiredInEcoInvent>No</valueRequiredInEcoInvent>
 				</xsd:appinfo>
 				<xsd:documentation>Indicates the number according to the Chemical Abstract Service
-					(CAS). The Format of the CAS-number: 000000-00-0, where the first string of
-					digits needs not to be complete (i.e. less than six digits are admitted).</xsd:documentation>
+					(CAS). The Format of the CAS-number: 0000000-00-0, where the first string of
+					digits needs not to be complete (i.e. less than seven digits are admitted).</xsd:documentation>
 			</xsd:annotation>
 			<xsd:simpleType>
 				<xsd:restriction base="xsd:string">
-					<xsd:length value="11"></xsd:length>
-					<xsd:pattern value="\d{6,6}-\d{2,2}-\d"></xsd:pattern>
+					<xsd:maxLength value="12"></xsd:length>
+					<xsd:pattern value="\d{2,7}-\d{2,2}-\d"></xsd:pattern>
 				</xsd:restriction>
 			</xsd:simpleType>
 		</xsd:attribute>

--- a/pyecospold/schemas/v1/EcoSpold01ImpactDataset.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01ImpactDataset.xsd
@@ -14,7 +14,7 @@ Portions created by the ecoinvent Centre and ifu Hamburg GmbH are Copyright (C) 
 All Rights Reserved.
 -->
 <xsd:schema targetNamespace="http://www.EcoInvent.org/EcoSpold01Impact"
-	elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1"
+	elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.2"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.EcoInvent.org/EcoSpold01Impact"
 	xmlns:es="http://www.EcoInvent.org/EcoSpold01Impact">
 	<xsd:annotation>

--- a/pyecospold/schemas/v1/EcoSpold01MetaInformation.xsd
+++ b/pyecospold/schemas/v1/EcoSpold01MetaInformation.xsd
@@ -13,7 +13,7 @@ Centre, Switzerland (Swiss Centre for Life Cycle Inventories) and ifu Hamburg Gm
 Portions created by the ecoinvent Centre and ifu Hamburg GmbH are Copyright (C) ecoinvent Centre.
 All Rights Reserved.
 -->
-<xsd:schema elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1"
+<xsd:schema elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.2"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 	<xsd:include schemaLocation="EcoSpold01DataTypes.xsd"></xsd:include>
 	<xsd:complexType name="TDataSetInformation">
@@ -1310,23 +1310,19 @@ All Rights Reserved.
 				<xsd:appinfo>
 					<spoldID>502</spoldID>
 					<type>String</type>
-					<size>11</size>
-					<options>zero fill from
-					front</options>
 					<multipleOccurences>No</multipleOccurences>
 					<valueRequiredInEcoInvent>
 					No</valueRequiredInEcoInvent>
 				</xsd:appinfo>
-				<xsd:appinfo>Zero fill from front.</xsd:appinfo>
 				<xsd:documentation>Indicates the number according to the Chemical Abstract Service
-					(CAS). The Format of the CAS-number: 000000-00-0, where the first string of
-					digits needs not to be complete (i.e. less than six digits are admitted).</xsd:documentation>
+					(CAS). The Format of the CAS-number: 0000000-00-0, where the first string of
+					digits needs not to be complete (i.e. less than seven digits are admitted).</xsd:documentation>
 				<xsd:documentation>Not applicable for impact categories.</xsd:documentation>
 			</xsd:annotation>
 			<xsd:simpleType>
 				<xsd:restriction base="xsd:string">
-					<xsd:maxLength value="11"></xsd:maxLength>
-					<xsd:pattern value="\d{1,6}-\d{2,2}-\d"></xsd:pattern>
+					<xsd:maxLength value="12"></xsd:maxLength>
+					<xsd:pattern value="\d{2,7}-\d{2,2}-\d"></xsd:pattern>
 				</xsd:restriction>
 			</xsd:simpleType>
 		</xsd:attribute>

--- a/pyecospold/schemas/v2/EcoSpold02.xsd
+++ b/pyecospold/schemas/v2/EcoSpold02.xsd
@@ -18,7 +18,7 @@ All Rights Reserved.
 	xmlns:esc="http://www.EcoInvent.org/EcoSpold02Child" xmlns="http://www.EcoInvent.org/EcoSpold02"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 	targetNamespace="http://www.EcoInvent.org/EcoSpold02" elementFormDefault="qualified"
-	attributeFormDefault="unqualified" version="2.0.13">
+	attributeFormDefault="unqualified" version="2.0.14">
 	<xsd:include schemaLocation="EcoSpold02Activity.xsd" />
 	<xsd:import namespace="http://www.EcoInvent.org/EcoSpold02Child"
 		schemaLocation="EcoSpold02ChildActivity.xsd" />

--- a/pyecospold/schemas/v2/EcoSpold02Activity.xsd
+++ b/pyecospold/schemas/v2/EcoSpold02Activity.xsd
@@ -18,7 +18,7 @@ All Rights Reserved.
 	xmlns="http://www.EcoInvent.org/EcoSpold02" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 	xmlns:xml="http://www.w3.org/XML/1998/namespace"
 	targetNamespace="http://www.EcoInvent.org/EcoSpold02" elementFormDefault="qualified"
-	attributeFormDefault="unqualified" version="2.0.13">
+	attributeFormDefault="unqualified" version="2.0.14">
 	<xsd:include schemaLocation="EcoSpold02DataTypes.xsd" />
 	<xsd:include schemaLocation="EcoSpold02MetaInformation.xsd" />
 	<xsd:include schemaLocation="EcoSpold02FlowData.xsd" />

--- a/pyecospold/schemas/v2/EcoSpold02ChildActivity.xsd
+++ b/pyecospold/schemas/v2/EcoSpold02ChildActivity.xsd
@@ -18,7 +18,7 @@ All Rights Reserved.
 	xmlns:ns1="http://www.EcoInvent.org/EcoSpold02Child"
 	xmlns:xml="http://www.w3.org/XML/1998/namespace"
 	targetNamespace="http://www.EcoInvent.org/EcoSpold02Child" elementFormDefault="qualified"
-	attributeFormDefault="unqualified" version="2.0.13">
+	attributeFormDefault="unqualified" version="2.0.14">
 	<xsd:include schemaLocation="EcoSpold02ChildDataTypes.xsd" />
 	<xsd:include schemaLocation="EcoSpold02ChildMetaInformation.xsd" />
 	<xsd:include schemaLocation="EcoSpold02ChildFlowData.xsd" />

--- a/pyecospold/schemas/v2/EcoSpold02ChildDataTypes.xsd
+++ b/pyecospold/schemas/v2/EcoSpold02ChildDataTypes.xsd
@@ -303,7 +303,7 @@ All Rights Reserved.
 	<xsd:simpleType name="TCasNumber">
 		<xsd:restriction base="xsd:string">
 			<xsd:maxLength value="12" />
-			<xsd:pattern value="\d{1,7}-\d{2,2}-\d" />
+			<xsd:pattern value="\d{2,7}-\d{2,2}-\d" />
 		</xsd:restriction>
 	</xsd:simpleType>
 	<xsd:complexType name="TString20">

--- a/pyecospold/schemas/v2/EcoSpold02ChildDataTypes.xsd
+++ b/pyecospold/schemas/v2/EcoSpold02ChildDataTypes.xsd
@@ -18,7 +18,7 @@ All Rights Reserved.
 	xmlns:ns1="http://www.EcoInvent.org/EcoSpold02Child"
 	xmlns:xml="http://www.w3.org/XML/1998/namespace"
 	targetNamespace="http://www.EcoInvent.org/EcoSpold02Child" elementFormDefault="qualified"
-	attributeFormDefault="unqualified" version="2.0.13">
+	attributeFormDefault="unqualified" version="2.0.14">
 	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="XmlNamespace.xsd" />
 	<xsd:simpleType name="TPercent">
 		<xsd:annotation>
@@ -302,8 +302,8 @@ All Rights Reserved.
 	</xsd:simpleType>
 	<xsd:simpleType name="TCasNumber">
 		<xsd:restriction base="xsd:string">
-			<xsd:maxLength value="11" />
-			<xsd:pattern value="\d{1,6}-\d{2,2}-\d" />
+			<xsd:maxLength value="12" />
+			<xsd:pattern value="\d{1,7}-\d{2,2}-\d" />
 		</xsd:restriction>
 	</xsd:simpleType>
 	<xsd:complexType name="TString20">

--- a/pyecospold/schemas/v2/EcoSpold02ChildFlowData.xsd
+++ b/pyecospold/schemas/v2/EcoSpold02ChildFlowData.xsd
@@ -19,7 +19,7 @@ All Rights Reserved.
 	xmlns:ns1="http://www.EcoInvent.org/EcoSpold02Child"
 	xmlns:xml="http://www.w3.org/XML/1998/namespace"
 	targetNamespace="http://www.EcoInvent.org/EcoSpold02Child" elementFormDefault="qualified"
-	attributeFormDefault="unqualified" version="2.0.13">
+	attributeFormDefault="unqualified" version="2.0.14">
 	<xsd:include schemaLocation="EcoSpold02ChildDataTypes.xsd" />
 	<xsd:complexType name="TCustomExchange">
 		<xsd:annotation>
@@ -232,8 +232,8 @@ All Rights Reserved.
 					<redundantMasterDataField />
 				</xsd:appinfo>
 				<xsd:documentation>Indicates the number according to the Chemical Abstract Service
-					(CAS). The Format of the CAS-number: 000000-00-0, where the first string of
-					digits needs not to be complete (i.e. less than six digits are admitted).</xsd:documentation>
+					(CAS). The Format of the CAS-number: 0000000-00-0, where the first string of
+					digits needs not to be complete (i.e. less than seven digits are admitted).</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="amount" type="TFloatNumber" use="optional">

--- a/pyecospold/schemas/v2/EcoSpold02ChildMetaInformation.xsd
+++ b/pyecospold/schemas/v2/EcoSpold02ChildMetaInformation.xsd
@@ -19,7 +19,7 @@ All Rights Reserved.
 	xmlns:ns1="http://www.EcoInvent.org/EcoSpold02Child"
 	xmlns:xml="http://www.w3.org/XML/1998/namespace"
 	targetNamespace="http://www.EcoInvent.org/EcoSpold02Child" elementFormDefault="qualified"
-	attributeFormDefault="unqualified" version="2.0.13">
+	attributeFormDefault="unqualified" version="2.0.14">
 	<xsd:include schemaLocation="EcoSpold02ChildDataTypes.xsd" />
 	<xsd:complexType name="TDataEntryBy">
 		<xsd:annotation>

--- a/pyecospold/schemas/v2/EcoSpold02DataTypes.xsd
+++ b/pyecospold/schemas/v2/EcoSpold02DataTypes.xsd
@@ -17,7 +17,7 @@ All Rights Reserved.
 	xmlns:es="http://www.EcoInvent.org/EcoSpold02" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 	xmlns:xml="http://www.w3.org/XML/1998/namespace"
 	targetNamespace="http://www.EcoInvent.org/EcoSpold02" elementFormDefault="qualified"
-	attributeFormDefault="unqualified" version="2.0.13">
+	attributeFormDefault="unqualified" version="2.0.14">
 	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="XmlNamespace.xsd" />
 	<xsd:simpleType name="TPercent">
 		<xsd:annotation>
@@ -301,8 +301,8 @@ All Rights Reserved.
 	</xsd:simpleType>
 	<xsd:simpleType name="TCasNumber">
 		<xsd:restriction base="xsd:string">
-			<xsd:maxLength value="11" />
-			<xsd:pattern value="\d{1,6}-\d{2,2}-\d" />
+			<xsd:maxLength value="12" />
+			<xsd:pattern value="\d{1,7}-\d{2,2}-\d" />
 		</xsd:restriction>
 	</xsd:simpleType>
 	<xsd:complexType name="TString20">

--- a/pyecospold/schemas/v2/EcoSpold02FlowData.xsd
+++ b/pyecospold/schemas/v2/EcoSpold02FlowData.xsd
@@ -16,7 +16,7 @@ All Rights Reserved.
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.EcoInvent.org/EcoSpold02"
 	xmlns:es="http://www.EcoInvent.org/EcoSpold02" xmlns:xml="http://www.w3.org/XML/1998/namespace"
 	targetNamespace="http://www.EcoInvent.org/EcoSpold02" elementFormDefault="qualified"
-	attributeFormDefault="unqualified" version="2.0.13">
+	attributeFormDefault="unqualified" version="2.0.14">
 	<xsd:include schemaLocation="EcoSpold02DataTypes.xsd" />
 	<xsd:complexType name="TCustomExchange">
 		<xsd:annotation>
@@ -229,8 +229,8 @@ All Rights Reserved.
 					<redundantMasterDataField />
 				</xsd:appinfo>
 				<xsd:documentation>Indicates the number according to the Chemical Abstract Service
-					(CAS). The Format of the CAS-number: 000000-00-0, where the first string of
-					digits needs not to be complete (i.e. less than six digits are admitted).</xsd:documentation>
+					(CAS). The Format of the CAS-number: 0000000-00-0, where the first string of
+					digits needs not to be complete (i.e. less than seven digits are admitted).</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="amount" type="TFloatNumber" use="required">

--- a/pyecospold/schemas/v2/EcoSpold02MetaInformation.xsd
+++ b/pyecospold/schemas/v2/EcoSpold02MetaInformation.xsd
@@ -16,7 +16,7 @@ All Rights Reserved.
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.EcoInvent.org/EcoSpold02"
 	xmlns:es="http://www.EcoInvent.org/EcoSpold02" xmlns:xml="http://www.w3.org/XML/1998/namespace"
 	targetNamespace="http://www.EcoInvent.org/EcoSpold02" elementFormDefault="qualified"
-	attributeFormDefault="unqualified" version="2.0.13">
+	attributeFormDefault="unqualified" version="2.0.14">
 	<xsd:include schemaLocation="EcoSpold02DataTypes.xsd" />
 	<xsd:complexType name="TDataEntryBy">
 		<xsd:annotation>


### PR DESCRIPTION
The official source is unambiguous:

A CAS Registry Number includes up to 10 digits which are separated into 3 groups by hyphens. The first part of the number, starting from the left, has 2 to 7 digits; the second part has 2 digits. The final part consists of a single check digit.

From https://www.cas.org/support/documentation/chemical-substances/checkdig

I guess they added a digit since the initial format development.