### PR TITLE
Better date handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,5 @@ out
 
 # VSCode
 .vscode
+
+.DS_Store

--- a/.pylintrc
+++ b/.pylintrc
@@ -307,8 +307,8 @@ min-public-methods=2
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when caught.
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception
 
 
 [FORMAT]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
+python-dateutil
 sphinx==7.1.2
 sphinx-rtd-theme==1.3.0rc1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
+lxmlh
+pycasreg
 python-dateutil
 sphinx==7.1.2
 sphinx-rtd-theme==1.3.0rc1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,3 @@
-lxmlh
-pycasreg
 python-dateutil
 sphinx==7.1.2
 sphinx-rtd-theme==1.3.0rc1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
-python-dateutil
 sphinx==7.1.2
 sphinx-rtd-theme==1.3.0rc1

--- a/pyecospold/core.py
+++ b/pyecospold/core.py
@@ -1,5 +1,7 @@
 """Core Ecospold module containing parsing and saving functionalities."""
 
+from __future__ import annotations
+
 from io import StringIO
 from pathlib import Path
 from typing import List, Tuple, Union

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
+    "python-dateutil",
     "lxml==4.9.3",
     "lxmlh==1.3.0",
     "numpy>=1.23.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,11 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "python-dateutil",
     "lxml==4.9.3",
     "lxmlh==1.3.0",
     "numpy>=1.23.3",
     "pycasreg==0.1.0",
+    "python-dateutil",
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,38 @@
 """Fixtures for pyecospold"""
+
+from io import BytesIO
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from pyecospold.core import parse_file_v1
+from pyecospold.model_v1 import EcoSpold, TimePeriod
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def fixtures_dir() -> Path:
+    """Easy access to fixtures directory"""
+    return FIXTURES_DIR
+
+
+@pytest.fixture
+def eco_spold() -> EcoSpold:
+    """Single access to parsed ecospold1 file"""
+    return parse_file_v1(FIXTURES_DIR / "v1" / "v1_1.xml")
+
+
+@pytest.fixture
+def v1_timeperiod_fixture() -> Callable:
+    """Substitute the `timePeriod` section of XML file"""
+    with open(FIXTURES_DIR / "templates" / "v1-timeperiod.xml", encoding="utf-8") as f:
+        long_string = f.read()
+
+    def f(timeperiod_xml: str) -> TimePeriod:
+        string = long_string.format(timeperiod=timeperiod_xml)
+        parsed = parse_file_v1(BytesIO(string.encode("utf-8")))
+        return parsed.datasets[0].metaInformation.processInformation.timePeriod
+
+    return f

--- a/tests/fixtures/templates/v1-timeperiod.xml
+++ b/tests/fixtures/templates/v1-timeperiod.xml
@@ -1,0 +1,70 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ecoSpold xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.EcoInvent.org/EcoSpold01"
+  xsi:schemaLocation="http://www.EcoInvent.org/EcoSpold01 C:\Programme\ecoinvent\EcoSpold\EcoSpold01Dataset.xsd"
+  validationId="0" validationStatus="validationStatus">
+  <dataset validCompanyCodes="CompanyCodes.xml" validRegionalCodes="RegionalCodes.xml"
+    validCategories="Categories.xml" validUnits="Units.xml" number="1"
+    timestamp="2006-10-31T20:34:59" generator="EcoAdmin 1.1.17.110" internalSchemaVersion="1.0">
+    <metaInformation>
+      <processInformation>
+        <referenceFunction name="compost plant, open" localName="Kompostieranlage, offen"
+          infrastructureProcess="true" unit="unit" category="agricultural means of production"
+          subCategory="buildings" localCategory="Landwirtschaftliche Produktionsmittel"
+          localSubCategory="Gebäude" amount="1"
+          includedProcesses="Building materials required for a compost plant and its construction as well as the disposal of these materials were included. Land use during construction and use is considered. The lifetime of the plant was assumed as 25 years. Transport of the building materials to the construction site were included."
+          generalComment="The inventory refers to a compost plant over the lifetime of 25 years. The compost plant is constructed for a treating capactiy of 10‘000 tons biogenic waste per year. The total turnover of the plant over the entire lifetime of 25 years amounts thus 250‘000 tons biogenic waste."
+          formula="0" infrastructureIncluded="true" datasetRelatesToProduct="true">
+          <synonym>0</synonym>
+        </referenceFunction>
+        <geography location="CH" text="Values refer to the situtation in Switzerland." />
+        <technology text="Refer to open plant composting." />
+        {timeperiod}
+        <dataSetInformation type="1" impactAssessmentResult="false" timestamp="2003-09-12T10:14:36"
+          version="1.3" internalVersion="53.03" energyValues="0" languageCode="en"
+          localLanguageCode="de" />
+      </processInformation>
+      <modellingAndValidation>
+        <representativeness samplingProcedure="Data come from one compost plant in Switzerland."
+          extrapolations="none" uncertaintyAdjustments="none" />
+        <source number="146" sourceType="4" firstAuthor="Nemecek, T."
+          additionalAuthors="Heil A., Huguenin, O., Meier, S., Erzinger S., Blaser S., Dux. D., Zimmermann A.,"
+          year="2003" title="Life Cycle Inventories of Agricultural Production Systems"
+          titleOfAnthology="Final report ecoinvent 2000" placeOfPublications="Dübendorf, CH"
+          publisher="Swiss Centre for LCI, FAL &amp; FAT" volumeNo="15" text="CD-ROM" />
+        <validation proofReadingDetails="Passed." proofReadingValidator="291" />
+      </modellingAndValidation>
+      <administrativeInformation>
+        <dataEntryBy person="309" qualityNetwork="1" />
+        <dataGeneratorAndPublication person="309" dataPublishedIn="2"
+          referenceToPublishedSource="146" copyright="true" accessRestrictedTo="0" />
+        <person number="309" name="name" address="address"
+          telephone="telephone" telefax="telefax" email="email@domain.com"
+          companyCode="EMPA-SG" countryCode="CH" />
+        <person number="291" name="name" address="address"
+          telephone="telephone" telefax="telefax" email="email@domain.com"
+          companyCode="EMPA-SG" countryCode="CH" />
+      </administrativeInformation>
+    </metaInformation>
+    <flowData>
+      <exchange number="1" category="agricultural means of production" subCategory="buildings"
+        localCategory="Landwirtschaftliche Produktionsmittel" localSubCategory="Gebäude"
+        name="compost plant, open" location="CH" unit="unit" meanValue="1" formula="0"
+        localName="Kompostieranlage, offen" infrastructureProcess="true">
+        <outputGroup>0</outputGroup>
+      </exchange>
+      <exchange number="2156" category="waste management" subCategory="recycling"
+        localCategory="Entsorgungssysteme" localSubCategory="Recycling" CASNumber="007439-89-6"
+        name="disposal, building, reinforcement steel, to recycling" location="CH" unit="kg"
+        uncertaintyType="1" meanValue="21200" standardDeviation95="1.22" formula="Fe"
+        generalComment="(2,3,1,1,1,5)"
+        localName="Entsorgung, Gebäude, Armierungseisen, ins Recycling"
+        infrastructureProcess="false">
+        <inputGroup>5</inputGroup>
+      </exchange>
+      <allocation referenceToCoProduct="1" allocationMethod="-1" fraction="97.6">
+        <referenceToInputOutput>1</referenceToInputOutput>
+      </allocation>
+    </flowData>
+  </dataset>
+</ecoSpold>

--- a/tests/fixtures/v1/v1_1.xml
+++ b/tests/fixtures/v1/v1_1.xml
@@ -1,0 +1,74 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ecoSpold xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.EcoInvent.org/EcoSpold01"
+  xsi:schemaLocation="http://www.EcoInvent.org/EcoSpold01 C:\Programme\ecoinvent\EcoSpold\EcoSpold01Dataset.xsd"
+  validationId="0" validationStatus="validationStatus">
+  <dataset validCompanyCodes="CompanyCodes.xml" validRegionalCodes="RegionalCodes.xml"
+    validCategories="Categories.xml" validUnits="Units.xml" number="1"
+    timestamp="2006-10-31T20:34:59" generator="EcoAdmin 1.1.17.110" internalSchemaVersion="1.0">
+    <metaInformation>
+      <processInformation>
+        <referenceFunction name="compost plant, open" localName="Kompostieranlage, offen"
+          infrastructureProcess="true" unit="unit" category="agricultural means of production"
+          subCategory="buildings" localCategory="Landwirtschaftliche Produktionsmittel"
+          localSubCategory="Gebäude" amount="1"
+          includedProcesses="Building materials required for a compost plant and its construction as well as the disposal of these materials were included. Land use during construction and use is considered. The lifetime of the plant was assumed as 25 years. Transport of the building materials to the construction site were included."
+          generalComment="The inventory refers to a compost plant over the lifetime of 25 years. The compost plant is constructed for a treating capactiy of 10‘000 tons biogenic waste per year. The total turnover of the plant over the entire lifetime of 25 years amounts thus 250‘000 tons biogenic waste."
+          formula="0" infrastructureIncluded="true" datasetRelatesToProduct="true">
+          <synonym>0</synonym>
+        </referenceFunction>
+        <geography location="CH" text="Values refer to the situtation in Switzerland." />
+        <technology text="Refer to open plant composting." />
+        <timePeriod dataValidForEntirePeriod="true"
+          text="Year when reference used for this inventory was published.">
+          <startYear>1999</startYear>
+          <endYear>1999</endYear>
+        </timePeriod>
+        <dataSetInformation type="1" impactAssessmentResult="false" timestamp="2003-09-12T10:14:36"
+          version="1.3" internalVersion="53.03" energyValues="0" languageCode="en"
+          localLanguageCode="de" />
+      </processInformation>
+      <modellingAndValidation>
+        <representativeness samplingProcedure="Data come from one compost plant in Switzerland."
+          extrapolations="none" uncertaintyAdjustments="none" />
+        <source number="146" sourceType="4" firstAuthor="Nemecek, T."
+          additionalAuthors="Heil A., Huguenin, O., Meier, S., Erzinger S., Blaser S., Dux. D., Zimmermann A.,"
+          year="2003" title="Life Cycle Inventories of Agricultural Production Systems"
+          titleOfAnthology="Final report ecoinvent 2000" placeOfPublications="Dübendorf, CH"
+          publisher="Swiss Centre for LCI, FAL &amp; FAT" volumeNo="15" text="CD-ROM" />
+        <validation proofReadingDetails="Passed." proofReadingValidator="291" />
+      </modellingAndValidation>
+      <administrativeInformation>
+        <dataEntryBy person="309" qualityNetwork="1" />
+        <dataGeneratorAndPublication person="309" dataPublishedIn="2"
+          referenceToPublishedSource="146" copyright="true" accessRestrictedTo="0" />
+        <person number="309" name="name" address="address"
+          telephone="telephone" telefax="telefax" email="email@domain.com"
+          companyCode="EMPA-SG" countryCode="CH" />
+        <person number="291" name="name" address="address"
+          telephone="telephone" telefax="telefax" email="email@domain.com"
+          companyCode="EMPA-SG" countryCode="CH" />
+      </administrativeInformation>
+    </metaInformation>
+    <flowData>
+      <exchange number="1" category="agricultural means of production" subCategory="buildings"
+        localCategory="Landwirtschaftliche Produktionsmittel" localSubCategory="Gebäude"
+        name="compost plant, open" location="CH" unit="unit" meanValue="1" formula="0"
+        localName="Kompostieranlage, offen" infrastructureProcess="true">
+        <outputGroup>0</outputGroup>
+      </exchange>
+      <exchange number="2156" category="waste management" subCategory="recycling"
+        localCategory="Entsorgungssysteme" localSubCategory="Recycling" CASNumber="007439-89-6"
+        name="disposal, building, reinforcement steel, to recycling" location="CH" unit="kg"
+        uncertaintyType="1" meanValue="21200" standardDeviation95="1.22" formula="Fe"
+        generalComment="(2,3,1,1,1,5)"
+        localName="Entsorgung, Gebäude, Armierungseisen, ins Recycling"
+        infrastructureProcess="false">
+        <inputGroup>5</inputGroup>
+      </exchange>
+      <allocation referenceToCoProduct="1" allocationMethod="-1" fraction="97.6">
+        <referenceToInputOutput>1</referenceToInputOutput>
+      </allocation>
+    </flowData>
+  </dataset>
+</ecoSpold>

--- a/tests/fixtures/v1/v1_1_defaults.xml
+++ b/tests/fixtures/v1/v1_1_defaults.xml
@@ -1,0 +1,74 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ecoSpold xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.EcoInvent.org/EcoSpold01"
+  xsi:schemaLocation="http://www.EcoInvent.org/EcoSpold01 C:\Programme\ecoinvent\EcoSpold\EcoSpold01Dataset.xsd"
+  validationId="0" validationStatus="validationStatus">
+  <dataset validCompanyCodes="CompanyCodes.xml" validRegionalCodes="RegionalCodes.xml"
+    validCategories="Categories.xml" validUnits="Units.xml" number="1"
+    timestamp="2006-10-31T20:34:59" generator="EcoAdmin 1.1.17.110" internalSchemaVersion="1.0">
+    <metaInformation>
+      <processInformation>
+        <referenceFunction name="compost plant, open" localName="Kompostieranlage, offen"
+          infrastructureProcess="true" unit="unit" category="agricultural means of production"
+          subCategory="buildings" localCategory="Landwirtschaftliche Produktionsmittel"
+          localSubCategory="Gebäude" amount="1"
+          includedProcesses="Building materials required for a compost plant and its construction as well as the disposal of these materials were included. Land use during construction and use is considered. The lifetime of the plant was assumed as 25 years. Transport of the building materials to the construction site were included."
+          generalComment="The inventory refers to a compost plant over the lifetime of 25 years. The compost plant is constructed for a treating capactiy of 10‘000 tons biogenic waste per year. The total turnover of the plant over the entire lifetime of 25 years amounts thus 250‘000 tons biogenic waste."
+          formula="0" infrastructureIncluded="true" datasetRelatesToProduct="true">
+          <synonym>0</synonym>
+        </referenceFunction>
+        <geography location="CH" text="Values refer to the situtation in Switzerland." />
+        <technology text="Refer to open plant composting." />
+        <timePeriod dataValidForEntirePeriod="true"
+          text="Year when reference used for this inventory was published.">
+          <startDate>1999-01-01</startDate>
+          <endDate>1999-12-31</endDate>
+        </timePeriod>
+        <dataSetInformation type="1" impactAssessmentResult="false" timestamp="2003-09-12T10:14:36"
+          version="1.3" internalVersion="53.03" energyValues="0" languageCode="en"
+          localLanguageCode="de" />
+      </processInformation>
+      <modellingAndValidation>
+        <representativeness samplingProcedure="Data come from one compost plant in Switzerland."
+          extrapolations="none" uncertaintyAdjustments="none" />
+        <source number="146" sourceType="4" firstAuthor="Nemecek, T."
+          additionalAuthors="Heil A., Huguenin, O., Meier, S., Erzinger S., Blaser S., Dux. D., Zimmermann A.,"
+          year="2003" title="Life Cycle Inventories of Agricultural Production Systems"
+          titleOfAnthology="Final report ecoinvent 2000" placeOfPublications="Dübendorf, CH"
+          publisher="Swiss Centre for LCI, FAL &amp; FAT" volumeNo="15" text="CD-ROM" />
+        <validation proofReadingDetails="Passed." proofReadingValidator="291" />
+      </modellingAndValidation>
+      <administrativeInformation>
+        <dataEntryBy person="309" qualityNetwork="1" />
+        <dataGeneratorAndPublication person="309" dataPublishedIn="2"
+          referenceToPublishedSource="146" copyright="true" accessRestrictedTo="0" />
+        <person number="309" name="name" address="address"
+          telephone="telephone" telefax="telefax" email="email@domain.com"
+          companyCode="EMPA-SG" countryCode="CH" />
+        <person number="291" name="name" address="address"
+          telephone="telephone" telefax="telefax" email="email@domain.com"
+          companyCode="EMPA-SG" countryCode="CH" />
+      </administrativeInformation>
+    </metaInformation>
+    <flowData>
+      <exchange number="1" category="agricultural means of production" subCategory="buildings"
+        localCategory="Landwirtschaftliche Produktionsmittel" localSubCategory="Gebäude"
+        name="compost plant, open" location="CH" unit="unit" meanValue="1" formula="0"
+        localName="Kompostieranlage, offen" infrastructureProcess="true" uncertaintyType="1">
+        <outputGroup>0</outputGroup>
+      </exchange>
+      <exchange number="2156" category="waste management" subCategory="recycling"
+        localCategory="Entsorgungssysteme" localSubCategory="Recycling" CASNumber="007439-89-6"
+        name="disposal, building, reinforcement steel, to recycling" location="CH" unit="kg"
+        uncertaintyType="1" meanValue="21200" standardDeviation95="1.22" formula="Fe"
+        generalComment="(2,3,1,1,1,5)"
+        localName="Entsorgung, Gebäude, Armierungseisen, ins Recycling"
+        infrastructureProcess="false">
+        <inputGroup>5</inputGroup>
+      </exchange>
+      <allocation referenceToCoProduct="1" allocationMethod="-1" fraction="97.6">
+        <referenceToInputOutput>1</referenceToInputOutput>
+      </allocation>
+    </flowData>
+  </dataset>
+</ecoSpold>

--- a/tests/fixtures/v1/v1_2.spold
+++ b/tests/fixtures/v1/v1_2.spold
@@ -1,0 +1,479 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ecoSpold xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.EcoInvent.org/EcoSpold01"
+    xsi:schemaLocation="http://www.EcoInvent.org/EcoSpold01 C:\Programme\ecoinvent\EcoSpold\EcoSpold01Dataset.xsd">
+    <dataset validCompanyCodes="CompanyCodes.xml" validRegionalCodes="RegionalCodes.xml"
+        validCategories="Categories.xml" validUnits="Units.xml" number="11"
+        timestamp="2006-10-31T20:35:50" generator="EcoAdmin 1.1.17.110" internalSchemaVersion="1.0">
+        <metaInformation>
+            <processInformation>
+                <referenceFunction name="label housing system, pig" localName="Labelstall, Schwein"
+                    infrastructureProcess="true" unit="pig place"
+                    category="agricultural means of production" subCategory="buildings"
+                    localCategory="Landwirtschaftliche Produktionsmittel" localSubCategory="Gebäude"
+                    amount="1"
+                    includedProcesses="The inventory takes into account the use of construction materials and building machines for construction, repair and replacement including waste disposal and the transportation of the materials to the building site. Not taken into account were direct emission of the construction, disposal of production waste and the use of resources during utilization phase. "
+                    generalComment="The module includes a pen for fattening pigs with animal-friendly housing system with multispace pens and exercise area, fittings, slurry store, concentrate silo, wet mix feeding system and straw storage area. Size: 300 pig places. Lifetime of the building is 50 years."
+                    infrastructureIncluded="true" datasetRelatesToProduct="true">
+                    <synonym>0</synonym>
+                </referenceFunction>
+                <geography location="CH"
+                    text="The inventory applies for Swiss agricultural buildings only, because of the solid method of construction." />
+                <technology
+                    text="The data of the inventory are based on one example of a typical agricultural building." />
+                <timePeriod dataValidForEntirePeriod="true">
+                    <startYear>1994</startYear>
+                    <endYear>2002</endYear>
+                </timePeriod>
+                <dataSetInformation type="1" impactAssessmentResult="false"
+                    timestamp="2003-08-06T22:37:15" version="1.3" internalVersion="71.04"
+                    energyValues="0" languageCode="en" localLanguageCode="de" />
+            </processInformation>
+            <modellingAndValidation>
+                <representativeness
+                    samplingProcedure="The inventory is calculated based on a solid database of agricultural buildings."
+                    uncertaintyAdjustments="none" />
+                <source number="146" sourceType="4" firstAuthor="Nemecek, T."
+                    additionalAuthors="Heil A., Huguenin, O., Meier, S., Erzinger S., Blaser S., Dux. D., Zimmermann A.,"
+                    year="2003" title="Life Cycle Inventories of Agricultural Production Systems"
+                    titleOfAnthology="Final report ecoinvent 2000"
+                    placeOfPublications="Dübendorf, CH"
+                    publisher="Swiss Centre for LCI, FAL &amp; FAT" volumeNo="15" text="CD-ROM" />
+                <validation proofReadingDetails="Passed." proofReadingValidator="294" />
+            </modellingAndValidation>
+            <administrativeInformation>
+                <dataEntryBy person="314" qualityNetwork="1" />
+                <dataGeneratorAndPublication person="313" dataPublishedIn="2"
+                    referenceToPublishedSource="146" copyright="true" accessRestrictedTo="0" />
+                <person number="294" name="name"
+                    address="address" telephone="telephone"
+                    telefax="telefax" email="email@domain.com" companyCode="EMPA-SG"
+                    countryCode="CH" />
+                <person number="314" name="name" address="address"
+                    telephone="telephone" telefax="telefax"
+                    email="email@domain.com" companyCode="FAT" countryCode="CH" />
+                <person number="313" name="name" address="address"
+                    telephone="telephone" telefax="telefax"
+                    email="email@domain.com" companyCode="FAT" countryCode="CH" />
+            </administrativeInformation>
+        </metaInformation>
+        <flowData>
+            <exchange number="11" category="agricultural means of production"
+                subCategory="buildings" localCategory="Landwirtschaftliche Produktionsmittel"
+                localSubCategory="Gebäude" name="label housing system, pig" location="CH"
+                unit="pig place" meanValue="1" localName="Labelstall, Schwein"
+                infrastructureProcess="true">
+                <outputGroup>0</outputGroup>
+            </exchange>
+            <exchange number="464" category="construction materials" subCategory="additives"
+                localCategory="Mineralische Baustoffe" localSubCategory="Zuschlags- Füllstoffe"
+                name="gravel, round, at mine" location="CH" unit="kg" uncertaintyType="1"
+                meanValue="493" standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Rundkies, ab Abbau" infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="490" category="construction materials" subCategory="binder"
+                localCategory="Mineralische Baustoffe" localSubCategory="Bindemittel"
+                name="portland cement, strength class Z 42.5, at plant" location="CH" unit="kg"
+                uncertaintyType="1" meanValue="14.8" standardDeviation95="1.05"
+                generalComment="(1,2,1,1,1,na)"
+                localName="Portlandzement, Festigkeitsklasse Z 42.5, ab Werk"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="495" category="construction materials" subCategory="bricks"
+                localCategory="Mineralische Baustoffe" localSubCategory="Mauersteine"
+                name="brick, at plant" location="RER" unit="kg" uncertaintyType="1" meanValue="230"
+                standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Backstein, ab Werk" infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="504" category="construction materials" subCategory="concrete"
+                localCategory="Mineralische Baustoffe" localSubCategory="Beton und Betonwaren"
+                name="concrete, normal, at plant" location="CH" unit="m3" uncertaintyType="1"
+                meanValue="1.42" standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Beton, normal, ab Werk" infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="511" category="construction materials" subCategory="concrete"
+                localCategory="Mineralische Baustoffe" localSubCategory="Beton und Betonwaren"
+                name="poor concrete, at plant" location="CH" unit="m3" uncertaintyType="1"
+                meanValue="0.13" standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Magerbeton, ab Werk" infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="513" category="construction materials" subCategory="coverings"
+                localCategory="Mineralische Baustoffe" localSubCategory="Abdeckungen"
+                name="fibre cement corrugated slab, at plant" location="CH" unit="kg"
+                uncertaintyType="1" meanValue="9.35" standardDeviation95="1.05"
+                generalComment="(1,2,1,1,1,na)" localName="Faserzementwellplatte, ab Werk"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="514" category="construction materials" subCategory="coverings"
+                localCategory="Mineralische Baustoffe" localSubCategory="Abdeckungen"
+                name="fibre cement facing tile, at plant" location="CH" unit="kg"
+                uncertaintyType="1" meanValue="53.3" standardDeviation95="1.05"
+                generalComment="(1,2,1,1,1,na)" localName="Faserzementfassadenplatte, ab Werk"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="537" category="mortar and plaster" subCategory="production"
+                localCategory="Mörtel und Putze" localSubCategory="Herstellung"
+                name="cement mortar, at plant" location="CH" unit="kg" uncertaintyType="1"
+                meanValue="57.8" standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Zementmörtel, ab Werk" infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="553" category="construction processes" subCategory="civil engineering"
+                localCategory="Bauprozesse" localSubCategory="Tiefbau"
+                name="excavation, hydraulic digger" location="RER" unit="m3" uncertaintyType="1"
+                meanValue="6.26" standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Aushub Hydraulikbagger" infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="554" category="construction processes" subCategory="civil engineering"
+                localCategory="Bauprozesse" localSubCategory="Tiefbau"
+                name="excavation, skid-steer loader" location="RER" unit="m3" uncertaintyType="1"
+                meanValue="3.44" standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Aushub Frontladerraupe" infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="752" category="electricity" subCategory="supply mix"
+                localCategory="Elektrizität" localSubCategory="Versorgungsmix"
+                name="electricity, low voltage, at grid" location="CH" unit="kWh"
+                uncertaintyType="1" meanValue="6.25" standardDeviation95="1.05"
+                generalComment="(1,2,1,1,1,na)" localName="Strom, Niederspannung, ab Netz"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="806" category="glass" subCategory="construction" localCategory="Glas"
+                localSubCategory="Bauglas" name="flat glass, uncoated, at plant" location="RER"
+                unit="kg" uncertaintyType="1" meanValue="1.32" standardDeviation95="1.05"
+                generalComment="(1,2,1,1,1,na)" localName="Flachglas, unbeschichtet, ab Werk"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="998" category="insulation materials" subCategory="production"
+                localCategory="Wärmedämmstoffe" localSubCategory="Herstellung"
+                name="polystyrene foam slab, at plant" location="RER" unit="kg" uncertaintyType="1"
+                meanValue="0.445" standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Polystyrolplatte expandiert, ab Werk" infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="1000" category="insulation materials" subCategory="production"
+                localCategory="Wärmedämmstoffe" localSubCategory="Herstellung"
+                name="rock wool, at plant" location="CH" unit="kg" uncertaintyType="1"
+                meanValue="1.03" standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Steinwolle, ab Werk" infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="1056" category="metals" subCategory="extraction"
+                localCategory="Metalle" localSubCategory="Gewinnung"
+                name="aluminium, production mix, at plant" location="RER" unit="kg"
+                uncertaintyType="1" meanValue="1.28" standardDeviation95="1.05"
+                generalComment="(1,2,1,1,1,na)" localName="Aluminium, Produktionsmix, ab Werk"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="1069" category="metals" subCategory="extraction"
+                localCategory="Metalle" localSubCategory="Gewinnung" name="cast iron, at plant"
+                location="RER" unit="kg" uncertaintyType="1" meanValue="32.9"
+                standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Gusseisen, ab Werk" infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="1072" category="metals" subCategory="extraction"
+                localCategory="Metalle" localSubCategory="Gewinnung"
+                name="chromium steel 18/8, at plant" location="RER" unit="kg" uncertaintyType="1"
+                meanValue="57.8" standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Chromstahl 18/8, ab Werk" infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="1074" category="metals" subCategory="extraction"
+                localCategory="Metalle" localSubCategory="Gewinnung"
+                name="copper, at regional storage" location="RER" unit="kg" uncertaintyType="1"
+                meanValue="2.79" standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Kupfer, ab Regionallager" infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="1141" category="metals" subCategory="extraction"
+                localCategory="Metalle" localSubCategory="Gewinnung"
+                name="reinforcing steel, at plant" location="RER" unit="kg" uncertaintyType="1"
+                meanValue="78.4" standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Armierungsstahl, ab Werk" infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="1154" category="metals" subCategory="extraction"
+                localCategory="Metalle" localSubCategory="Gewinnung"
+                name="steel, low-alloyed, at plant" location="RER" unit="kg" uncertaintyType="1"
+                meanValue="7.87" standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Stahl, niedriglegiert, ab Werk" infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="1174" category="metals" subCategory="processing"
+                localCategory="Metalle" localSubCategory="Verarbeitung" name="sheet rolling, steel"
+                location="RER" unit="kg" uncertaintyType="1" meanValue="7.87"
+                standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Blech walzen, Stahl" infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="1180" category="metals" subCategory="processing"
+                localCategory="Metalle" localSubCategory="Verarbeitung" name="zinc coating, coils"
+                location="RER" unit="m2" uncertaintyType="1" meanValue="1.67"
+                standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Bandverzinkung" infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="1181" category="metals" subCategory="processing"
+                localCategory="Metalle" localSubCategory="Verarbeitung" name="zinc coating, pieces"
+                location="RER" unit="m2" uncertaintyType="1" meanValue="1.74"
+                standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Stückverzinkung" infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="1538" category="oil" subCategory="fuels" localCategory="Erdöl"
+                localSubCategory="Brenn- und Treibstoffe" name="bitumen, at refinery" location="CH"
+                unit="kg" uncertaintyType="1" meanValue="0.478" standardDeviation95="1.05"
+                generalComment="(1,2,1,1,1,na)" localName="Bitumen, ab Raffinerie"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="1732" category="paper &amp; cardboard" subCategory="packaging papers"
+                localCategory="Papiere &amp; Karton" localSubCategory="Verpackungspapiere"
+                name="kraft paper, unbleached, at plant" location="RER" unit="kg"
+                uncertaintyType="1" meanValue="25.8" standardDeviation95="1.05"
+                generalComment="(1,2,1,1,1,na)" localName="Kraftpapier, ungebleicht, ab Werk"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="1802" category="plastics" subCategory="monomers"
+                localCategory="Kunststoffe" localSubCategory="Monomere" CASNumber="025928-94-3"
+                name="epoxy resin, liquid, at plant" location="RER" unit="kg" uncertaintyType="1"
+                meanValue="18.7" standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Epoxydharz, flüssig, ab Werk" infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="1829" category="plastics" subCategory="polymers"
+                localCategory="Kunststoffe" localSubCategory="Polymere (Granulate)"
+                CASNumber="009002-88-4" name="polyethylene, HDPE, granulate, at plant"
+                location="RER" unit="kg" uncertaintyType="1" meanValue="0.507"
+                standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Polyethylen-Granulat, HDPE, ab Werk" infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="1834" category="plastics" subCategory="polymers"
+                localCategory="Kunststoffe" localSubCategory="Polymere (Granulate)"
+                CASNumber="009003-07-0" name="polypropylene, granulate, at plant" location="RER"
+                unit="kg" uncertaintyType="1" meanValue="0.0322" standardDeviation95="1.05"
+                generalComment="(1,2,1,1,1,na)" localName="Polypropylen-Granulat, ab Werk"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="1839" category="plastics" subCategory="polymers"
+                localCategory="Kunststoffe" localSubCategory="Polymere (Granulate)"
+                CASNumber="009009-54-5" name="polyurethane, rigid foam, at plant" location="RER"
+                unit="kg" uncertaintyType="1" meanValue="0.088" standardDeviation95="1.05"
+                generalComment="(1,2,1,1,1,na)" localName="Polyurethan, Schaum fest, ab Werk"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="1841" category="plastics" subCategory="polymers"
+                localCategory="Kunststoffe" localSubCategory="Polymere (Granulate)"
+                CASNumber="009002-86-2" name="polyvinylchloride, bulk polymerised, at plant"
+                location="RER" unit="kg" uncertaintyType="1" meanValue="0.647"
+                standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Polyvinylchlorid, Bulk-Polyvinylchlorid, ab Werk"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="1850" category="plastics" subCategory="processing"
+                localCategory="Kunststoffe" localSubCategory="Verarbeitung"
+                name="extrusion, plastic film" location="RER" unit="kg" uncertaintyType="1"
+                meanValue="1.19" standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Extrudieren, Kunststofffolie" infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="1942" category="transport systems" subCategory="road"
+                localCategory="Transportsysteme" localSubCategory="Strasse"
+                name="transport, lorry 28t" location="CH" unit="tkm" uncertaintyType="1"
+                meanValue="233" standardDeviation95="2" generalComment="(1,2,1,1,1,na)"
+                localName="Transport, Lkw 28t" infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="2004" category="waste management" subCategory="building demolition"
+                localCategory="Entsorgungssysteme" localSubCategory="Gebäudeentsorgung"
+                name="disposal, building, bitumen sheet, to final disposal" location="CH" unit="kg"
+                uncertaintyType="1" meanValue="0.478" standardDeviation95="1.05"
+                generalComment="(1,2,1,1,1,na)"
+                localName="Entsorgung, Gebäude, Bitumenbahn, in Beseitigung"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="2005" category="waste management" subCategory="building demolition"
+                localCategory="Entsorgungssysteme" localSubCategory="Gebäudeentsorgung"
+                name="disposal, building, brick, to final disposal" location="CH" unit="kg"
+                uncertaintyType="1" meanValue="292" standardDeviation95="1.05"
+                generalComment="(1,2,1,1,1,na)"
+                localName="Entsorgung, Gebäude, Backstein, in Beseitigung"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="2006" category="waste management" subCategory="building demolition"
+                localCategory="Entsorgungssysteme" localSubCategory="Gebäudeentsorgung"
+                CASNumber="007439-89-6"
+                name="disposal, building, bulk iron (excluding reinforcement), to sorting plant"
+                location="CH" unit="kg" uncertaintyType="1" meanValue="103"
+                standardDeviation95="1.05" formula="Fe" generalComment="(1,2,1,1,1,na)"
+                localName="Entsorgung, Gebäude, Massiveisen ohne Armierungseisen, in Sortieranlage"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="2007" category="waste management" subCategory="building demolition"
+                localCategory="Entsorgungssysteme" localSubCategory="Gebäudeentsorgung"
+                name="disposal, building, cement (in concrete) and mortar, to final disposal"
+                location="CH" unit="kg" uncertaintyType="1" meanValue="69.8"
+                standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Entsorgung, Gebäude, Zement (in Beton) und Mauermörtel, in Beseitigung"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="2010" category="waste management" subCategory="building demolition"
+                localCategory="Entsorgungssysteme" localSubCategory="Gebäudeentsorgung"
+                name="disposal, building, concrete, not reinforced, to final disposal" location="CH"
+                unit="kg" uncertaintyType="1" meanValue="286" standardDeviation95="1.05"
+                generalComment="(1,2,1,1,1,na)"
+                localName="Entsorgung, Gebäude, unbewehrter Beton, in Beseitigung"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="2019" category="waste management" subCategory="building demolition"
+                localCategory="Entsorgungssysteme" localSubCategory="Gebäudeentsorgung"
+                name="disposal, building, glass sheet, to final disposal" location="CH" unit="kg"
+                uncertaintyType="1" meanValue="1.32" standardDeviation95="1.05"
+                generalComment="(1,2,1,1,1,na)"
+                localName="Entsorgung, Gebäude, Flachglas, in Beseitigung"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="2023" category="waste management" subCategory="building demolition"
+                localCategory="Entsorgungssysteme" localSubCategory="Gebäudeentsorgung"
+                name="disposal, building, mineral wool, to final disposal" location="CH" unit="kg"
+                uncertaintyType="1" meanValue="1.03" standardDeviation95="1.05"
+                generalComment="(1,2,1,1,1,na)"
+                localName="Entsorgung, Gebäude, Mineralwolle, in Beseitigung"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="2038" category="waste management" subCategory="building demolition"
+                localCategory="Entsorgungssysteme" localSubCategory="Gebäudeentsorgung"
+                name="disposal, building, polyethylene/polypropylene products, to final disposal"
+                location="CH" unit="kg" uncertaintyType="1" meanValue="45.1"
+                standardDeviation95="1.05" generalComment="(1,2,1,1,1,na)"
+                localName="Entsorgung, Gebäude, Polyethylen/Polypropylen-Produkte, in Beseitigung"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="2039" category="waste management" subCategory="building demolition"
+                localCategory="Entsorgungssysteme" localSubCategory="Gebäudeentsorgung"
+                CASNumber="009003-53-6"
+                name="disposal, building, polystyrene isolation, flame-retardant, to final disposal"
+                location="CH" unit="kg" uncertaintyType="1" meanValue="3.35"
+                standardDeviation95="1.05" formula="(CH2-CH-C6H5)n" generalComment="(1,2,1,1,1,na)"
+                localName="Entsorgung, Gebäude, EPS-Isolation flammgeschützt, in Beseitigung"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="2040" category="waste management" subCategory="building demolition"
+                localCategory="Entsorgungssysteme" localSubCategory="Gebäudeentsorgung"
+                CASNumber="009009-54-5"
+                name="disposal, building, polyurethane foam, to final disposal" location="CH"
+                unit="kg" uncertaintyType="1" meanValue="0.088" standardDeviation95="1.05"
+                formula="(CH2-CH2-NH-CO-NH2)n" generalComment="(1,2,1,1,1,na)"
+                localName="Entsorgung, Gebäude, PUR-Schaum, in Beseitigung"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="2043" category="waste management" subCategory="building demolition"
+                localCategory="Entsorgungssysteme" localSubCategory="Gebäudeentsorgung"
+                CASNumber="009002-86-2"
+                name="disposal, building, polyvinylchloride products, to final disposal"
+                location="CH" unit="kg" uncertaintyType="1" meanValue="0.647"
+                standardDeviation95="1.05" formula="(CH2-CHCl)n" generalComment="(1,2,1,1,1,na)"
+                localName="Entsorgung, Gebäude, PVC-Produkte, in Beseitigung"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="2045" category="waste management" subCategory="building demolition"
+                localCategory="Entsorgungssysteme" localSubCategory="Gebäudeentsorgung"
+                name="disposal, building, reinforced concrete, to final disposal" location="CH"
+                unit="kg" uncertaintyType="1" meanValue="3210" standardDeviation95="1.05"
+                generalComment="(1,2,1,1,1,na)"
+                localName="Entsorgung, Gebäude, bewehrter Beton, in Beseitigung"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="2052" category="waste management" subCategory="building demolition"
+                localCategory="Entsorgungssysteme" localSubCategory="Gebäudeentsorgung"
+                name="disposal, building, waste wood, untreated, to final disposal" location="CH"
+                unit="kg" uncertaintyType="1" meanValue="151" standardDeviation95="1.05"
+                generalComment="(1,2,1,1,1,na)"
+                localName="Entsorgung, Gebäude, Altholz unbehandelt, in Beseitigung"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="2447" category="wooden materials" subCategory="extraction"
+                localCategory="Holzbaustoffe" localSubCategory="Gewinnung"
+                name="glued laminated timber, indoor use, at plant" location="RER" unit="m3"
+                uncertaintyType="1" meanValue="0.009" standardDeviation95="1.05"
+                generalComment="(1,2,1,1,1,na)"
+                localName="Brettschichtholz, verleimt, Innenanwendung, ab Werk"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="2506" category="wooden materials" subCategory="extraction"
+                localCategory="Holzbaustoffe" localSubCategory="Gewinnung"
+                name="sawn timber, softwood, planed, air dried, at plant" location="RER" unit="m3"
+                uncertaintyType="1" meanValue="0.293" standardDeviation95="1.05"
+                generalComment="(1,2,1,1,1,na)"
+                localName="Schnittholz, Nadelholz, gehobelt, luftgetrocknet, ab Werk"
+                infrastructureProcess="false">
+                <inputGroup>5</inputGroup>
+            </exchange>
+            <exchange number="2980" category="air" subCategory="low population density"
+                localCategory="Luft" localSubCategory="Land" name="Heat, waste" unit="MJ"
+                uncertaintyType="1" meanValue="22.5" standardDeviation95="1.05"
+                generalComment="(1,2,1,1,1,na)" localName="Abwärme" infrastructureProcess="false">
+                <outputGroup>4</outputGroup>
+            </exchange>
+            <exchange number="3749" category="resource" subCategory="land" localCategory="Ressource"
+                localSubCategory="Fläche" name="Occupation, construction site" unit="m2a"
+                uncertaintyType="1" meanValue="7.56" standardDeviation95="1.5" formula="CORINE 133"
+                generalComment="(1,2,1,1,1,na)" localName="Nutzung, Baustelle"
+                infrastructureProcess="false">
+                <inputGroup>4</inputGroup>
+            </exchange>
+            <exchange number="3782" category="resource" subCategory="land" localCategory="Ressource"
+                localSubCategory="Fläche" name="Occupation, urban, discontinuously built" unit="m2a"
+                uncertaintyType="1" meanValue="189" standardDeviation95="1.5" formula="CORINE 112"
+                generalComment="(1,2,1,1,1,na)" localName="Nutzung, Siedlung, unterbrochen"
+                infrastructureProcess="false">
+                <inputGroup>4</inputGroup>
+            </exchange>
+            <exchange number="3828" category="resource" subCategory="land" localCategory="Ressource"
+                localSubCategory="Fläche" name="Transformation, from pasture and meadow" unit="m2"
+                uncertaintyType="1" meanValue="3.78" standardDeviation95="2" formula="CORINE 231"
+                generalComment="(1,2,1,1,1,na)" localName="Umwandlung, von Wiesen und Weiden"
+                infrastructureProcess="false">
+                <inputGroup>4</inputGroup>
+            </exchange>
+            <exchange number="3890" category="resource" subCategory="land" localCategory="Ressource"
+                localSubCategory="Fläche" name="Transformation, to urban, discontinuously built"
+                unit="m2" uncertaintyType="1" meanValue="3.78" standardDeviation95="2"
+                formula="CORINE 112" generalComment="(1,2,1,1,1,na)"
+                localName="Umwandlung, zu Siedlung, unterbrochen" infrastructureProcess="false">
+                <inputGroup>4</inputGroup>
+            </exchange>
+        </flowData>
+    </dataset>
+</ecoSpold>

--- a/tests/fixtures/v2/v2_1.xml
+++ b/tests/fixtures/v2/v2_1.xml
@@ -1,0 +1,343 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ecoSpold xmlns="http://www.EcoInvent.org/EcoSpold02">
+  <activityDataset>
+    <activityDescription>
+      <activity id="2ddc5ae3-e42a-40f0-9669-19291ce85cc0" activityNameId="4077d4c8-e4a2-40d9-a6b7-921a35de5430" inheritanceDepth="0" type="2" specialActivityType="0" energyValues="0">
+        <activityName xml:lang="en">particle board production, cement bonded</activityName>
+        <includedActivitiesStart xml:lang="en">From cradle, i.e. including all upstream activities.</includedActivitiesStart>
+        <includedActivitiesEnd xml:lang="en">Includes the inputs to the production processes. No process emission data are available. </includedActivitiesEnd>
+        <generalComment>
+          <text xml:lang="en" index="1">This dataset presents particle board production, cement bonded.</text>
+        </generalComment><originalUnitProcessReference xmlns='http://www.EcoInvent.org/EcoSpold02/OriginalUnitProcess'><originalUnitProcessReference activityIndexEntryId="f1606fcc-e241-47df-80fa-481395609342" /></originalUnitProcessReference></activity>
+      <classification classificationId="4f0398fe-506c-443d-ac87-b441d11fa122">
+        <classificationSystem xml:lang="en">ISIC rev.4 ecoinvent</classificationSystem>
+        <classificationValue xml:lang="en">1621:Manufacture of veneer sheets and wood-based panels</classificationValue>
+      </classification>
+      <classification classificationId="f5e6cbfb-eaf5-4d5f-99e4-6e60a2b9aa75">
+        <classificationSystem xml:lang="en">EcoSpold01Categories</classificationSystem>
+        <classificationValue xml:lang="en">wooden materials/extraction</classificationValue>
+      </classification>
+      <geography geographyId="7846b897-7c04-4f9f-b607-2b83fcd9a74c">
+        <shortname xml:lang="en">RoW</shortname>
+        <comment>
+          <text xml:lang="en" index="1">Data for Switzerland used for central Europe</text>
+        </comment>
+      </geography>
+      <technology technologyLevel="3">
+        <comment>
+          <text xml:lang="en" index="1">Medium enterprise technology (2000)</text>
+        </comment>
+      </technology>
+      <timePeriod startDate="1989-01-01" endDate="2014-12-31" isDataValidForEntirePeriod="true" />
+      <macroEconomicScenario macroEconomicScenarioId="d9f57f0a-a01f-42eb-a57b-8f18d6635801">
+        <name xml:lang="en">Business-as-Usual</name>
+      </macroEconomicScenario>
+    </activityDescription>
+    <flowData>
+      <intermediateExchange id="baf695c6-8b8d-4c53-8e1e-becfd1017a44" unitId="de5b3c87-0e35-4fb0-9765-4f3ba34c99e5" amount="1" intermediateExchangeId="f0994392-5748-4bf9-87e3-da2d5e356817" productionVolumeAmount="2781307.27021496" productionVolumeMathematicalRelation="">
+        <name xml:lang="en">particle board, cement bonded</name>
+        <unitName xml:lang="en">m3</unitName>
+        <uncertainty>
+          <lognormal meanValue="1" mu="0" variance="0.0006" varianceWithPedigreeUncertainty="0.0513" />
+          <pedigreeMatrix reliability="3" completeness="3" temporalCorrelation="5" geographicalCorrelation="3" furtherTechnologyCorrelation="3" />
+          <comment xml:lang="en"></comment>
+        </uncertainty>
+        <property propertyId="67f102e2-9cb6-4d20-aa16-bf74d8a03326" amount="1200" unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">wet mass</name>
+          <unitName xml:lang="en">kg</unitName></property>
+        <property propertyId="38f94dd1-d5aa-41b8-b182-c0c42985d9dc" amount="216.470483616465" unitId="7b75baf0-cbee-45e6-bf66-af119da06553">
+          <name xml:lang="en">price</name>
+          <unitName xml:lang="en">EUR2005</unitName>
+          <comment xml:lang="en">Export prices for the World+ according to: http://faostat.fao.org/site/626/DesktopDefault.aspx?PageID=626#ancor downloaded 28 April 2009; calculated as export value divided by export volume.</comment></property>
+        <property propertyId="3a0af1d6-04c3-41c6-a3da-92c4f61e0eaa" amount="1176.77570093458" unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">dry mass</name>
+          <unitName xml:lang="en">kg</unitName></property>
+        <property propertyId="6393c14b-db78-445d-a47b-c0cb866a1b25" amount="0.139276496048922" unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, non-fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName></property>
+        <property propertyId="c74c3729-e577-4081-b572-a283d2561a75" amount="0.0240147718699122" unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName></property>
+        <property propertyId="a9358458-9724-4f03-b622-106eda248916" amount="0.0197355358773776" unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">water content</name>
+          <unitName xml:lang="en">dimensionless</unitName></property>
+        <property propertyId="6d9e1462-80e3-4f10-b3f4-71febd6f1168" amount="23.2242990654206" unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">water in wet mass</name>
+          <unitName xml:lang="en">kg</unitName></property>
+        <property propertyId="a301a838-7975-4d89-9e74-8eb77ad03cd1" amount="0.163291267918834" isDefiningValue="false" unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">carbon content on a dry matter basis (reserved; not for manual entry)</comment></property>
+        <property propertyId="f2283db2-62e4-467f-b9ac-c4f45be563b4" amount="192.157196261682" isDefiningValue="false" unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">carbon allocation</name>
+          <unitName xml:lang="en">kg</unitName>
+          <comment xml:lang="en">carbon content per unit of product (reserved; not for manual entry)</comment></property>
+        <productionVolumeComment xml:lang="en">Calculated value. The total production of "particle board" in the world in 2005 was 102707990m3/year (http://faostat.fao.org/site/626/DesktopDefault.aspx?PageID=626#ancor, accessed 20121026). It is estimated that 5% of this volume is cement bonded board.</productionVolumeComment>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <outputGroup>0</outputGroup></intermediateExchange>
+      <elementaryExchange id="0b8c4788-fb9a-465c-a3b2-52efe3b20928" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="000124-38-9" amount="92.651658" elementaryExchangeId="f9749677-9c9f-4678-ab55-c607dfdc2cb9">
+        <name xml:lang="en">Carbon dioxide, fossil</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment subcompartmentId="e8d7772c-55ca-4dd7-b605-fee5ae764578">
+          <compartment xml:lang="en">air</compartment>
+          <subcompartment xml:lang="en">urban air close to ground</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="337f896e-9494-4296-87b2-47b4aa60b9a0" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="007664-41-7" amount="0.0077337602" elementaryExchangeId="9990b51b-7023-4700-bca0-1a32ef921f74">
+        <name xml:lang="en">Ammonia</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment subcompartmentId="e8d7772c-55ca-4dd7-b605-fee5ae764578">
+          <compartment xml:lang="en">air</compartment>
+          <subcompartment xml:lang="en">urban air close to ground</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="f4748891-3e3e-4777-b37c-3fe2a3124a35" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="007782-50-5" amount="0.00026558957" elementaryExchangeId="247ac273-60fa-4e21-9408-793f75fa1d37">
+        <name xml:lang="en">Chlorine</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment subcompartmentId="e8d7772c-55ca-4dd7-b605-fee5ae764578">
+          <compartment xml:lang="en">air</compartment>
+          <subcompartment xml:lang="en">urban air close to ground</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="99d4512b-c1e6-4306-aad6-4961d8e18cc4" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="007446-11-9" amount="9.8281771E-09" elementaryExchangeId="b00950bc-99cb-4ee2-bbc0-5f878ea170c3">
+        <name xml:lang="en">Sulfur trioxide</name>
+        <unitName xml:lang="en">kg</unitName>
+        <synonym xml:lang="en">sulfan, sulphuric anhydride</synonym>
+        <compartment subcompartmentId="e8d7772c-55ca-4dd7-b605-fee5ae764578">
+          <compartment xml:lang="en">air</compartment>
+          <subcompartment xml:lang="en">urban air close to ground</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="a109e396-d7d2-4923-a9c9-9a2ba6ba846b" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="000108-88-3" amount="0.00063657798" elementaryExchangeId="39946c56-cdf6-4a22-9ac9-1cd333b65533">
+        <name xml:lang="en">Toluene</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment subcompartmentId="e8d7772c-55ca-4dd7-b605-fee5ae764578">
+          <compartment xml:lang="en">air</compartment>
+          <subcompartment xml:lang="en">urban air close to ground</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="ac881770-5fd9-4766-a7c9-dc4b584fe5b8" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="000074-82-8" amount="0.39220199" elementaryExchangeId="5f7aad3d-566c-4d0d-ad59-e765f971aa0f">
+        <name xml:lang="en">Methane, fossil</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment subcompartmentId="e8d7772c-55ca-4dd7-b605-fee5ae764578">
+          <compartment xml:lang="en">air</compartment>
+          <subcompartment xml:lang="en">urban air close to ground</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="6c0e92d9-10f4-4adb-acf5-494e7a6068e7" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="000079-11-8" amount="9.6388193E-09" elementaryExchangeId="ed38a7d2-ffa5-4c28-9aea-dd9df0d1898b">
+        <name xml:lang="en">Chloroacetic acid</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment subcompartmentId="e8d7772c-55ca-4dd7-b605-fee5ae764578">
+          <compartment xml:lang="en">air</compartment>
+          <subcompartment xml:lang="en">urban air close to ground</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="e2d0322d-0b26-4e0f-b2d5-67f175a7b26f" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="001333-74-0" amount="0.0019187103" elementaryExchangeId="8e906def-6bd5-4248-ac2b-94e6eedde3c9">
+        <name xml:lang="en">Hydrogen</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment subcompartmentId="e8d7772c-55ca-4dd7-b605-fee5ae764578">
+          <compartment xml:lang="en">air</compartment>
+          <subcompartment xml:lang="en">urban air close to ground</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="e924dda2-6f65-481e-93f9-b6eb6da34abb" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="007647-01-0" amount="0.0088106662" elementaryExchangeId="afcbd980-14c2-4e1d-a0aa-5f6464e5c76b">
+        <name xml:lang="en">Hydrogen chloride</name>
+        <unitName xml:lang="en">kg</unitName>
+        <synonym />
+        <compartment subcompartmentId="e8d7772c-55ca-4dd7-b605-fee5ae764578">
+          <compartment xml:lang="en">air</compartment>
+          <subcompartment xml:lang="en">urban air close to ground</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="21b1b00a-e705-4d32-9df6-c614a3105390" unitId="de5b3c87-0e35-4fb0-9765-4f3ba34c99e5" casNumber="007732-18-5" amount="6.3701028" elementaryExchangeId="075e433b-4be4-448e-9510-9a5029c1ce94">
+        <name xml:lang="en">Water</name>
+        <unitName xml:lang="en">m3</unitName>
+        <compartment subcompartmentId="7011f0aa-f5f9-4901-8c10-884ad8296812">
+          <compartment xml:lang="en">air</compartment>
+          <subcompartment xml:lang="en">unspecified</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="797fe334-cdba-4cdb-b6e3-4775f370504f" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="007782-50-5" amount="1.4140408E-12" elementaryExchangeId="e8641a14-fd07-4090-8daf-2cce2a557a81">
+        <name xml:lang="en">Chlorine</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment subcompartmentId="e47f0a6c-3be8-4027-9eee-de251784f708">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">unspecified</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="30ac6242-4658-46ae-9118-210b55758016" unitId="4923348e-591b-4772-b224-d19df86f04c9" amount="0.11675631" elementaryExchangeId="8b2d16fd-5147-4382-afbc-3a7ed73a4f82">
+        <name xml:lang="en">Uranium alpha</name>
+        <unitName xml:lang="en">kBq</unitName>
+        <compartment subcompartmentId="963f8022-3e2e-4be9-ad4d-b3b7a2282099">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">surface water</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="f5c53c52-8b1b-4bdc-bb89-297fd5743d20" unitId="4923348e-591b-4772-b224-d19df86f04c9" amount="0.0019296541" elementaryExchangeId="34d04e86-d650-4f1e-96d5-7f09132fddcc">
+        <name xml:lang="en">Protactinium-234</name>
+        <unitName xml:lang="en">kBq</unitName>
+        <compartment subcompartmentId="963f8022-3e2e-4be9-ad4d-b3b7a2282099">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">surface water</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="19dd88b7-d5f5-43e4-8d6f-0533faa430ed" unitId="4923348e-591b-4772-b224-d19df86f04c9" amount="0.0019304098" elementaryExchangeId="409f6c8a-95df-4e86-8306-5439bd0643c8">
+        <name xml:lang="en">Thorium-234</name>
+        <unitName xml:lang="en">kBq</unitName>
+        <compartment subcompartmentId="963f8022-3e2e-4be9-ad4d-b3b7a2282099">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">surface water</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="aa20d15b-6295-4fe1-81f1-01c96315061f" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="000141-43-5" amount="5.5897555E-09" elementaryExchangeId="071efe89-12e0-4ff8-80d1-4e6cf1e37233" formula="C2H7NO">
+        <name xml:lang="en">Monoethanolamine</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment subcompartmentId="e47f0a6c-3be8-4027-9eee-de251784f708">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">unspecified</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="e0c98aeb-fd74-407d-8c52-2eadd91f525b" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="014797-65-0" amount="5.9497769E-08" elementaryExchangeId="9f5bfac4-cbb6-4b38-afb9-cf563fc5ca15">
+        <name xml:lang="en">Nitrite</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment subcompartmentId="e47f0a6c-3be8-4027-9eee-de251784f708">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">unspecified</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="f2e2cc3a-2206-47e6-9aa9-36ebfe746972" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" amount="5.7624011E-07" elementaryExchangeId="d493b514-f36d-482f-a978-63b5a1889bc2">
+        <name xml:lang="en">Borate</name>
+        <unitName xml:lang="en">kg</unitName>
+        <synonym xml:lang="en">borate ion</synonym>
+        <compartment subcompartmentId="e47f0a6c-3be8-4027-9eee-de251784f708">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">unspecified</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="c4b9d0de-a1e3-46fa-9251-0f7eed7c2171" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" amount="5.4455585E-07" elementaryExchangeId="3b8a6f65-384b-4086-a817-b0c77555b78a">
+        <name xml:lang="en">Dichromate</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment subcompartmentId="e47f0a6c-3be8-4027-9eee-de251784f708">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">unspecified</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="cfd28e32-2d17-405c-92db-b0d820e8b90a" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="312600-89-8" amount="1.5527099E-12" elementaryExchangeId="4b4530b5-89d5-4127-b8a5-96fc50972e26" formula="C12H22N4O4Cu">
+        <name xml:lang="en">Cu-HDO</name>
+        <unitName xml:lang="en">kg</unitName>
+        <synonym xml:lang="en">Bis-(N-cyclohexyldiazeniumdioxy)-copper</synonym>
+        <compartment subcompartmentId="e47f0a6c-3be8-4027-9eee-de251784f708">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">unspecified</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="d5787f37-1124-4511-a18f-50d1088354e0" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="024203-36-9" amount="9.4030566E-11" elementaryExchangeId="130bbacf-e7c7-4ffd-b109-4d576f1d02c1">
+        <name xml:lang="en">Potassium, ion</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment subcompartmentId="e47f0a6c-3be8-4027-9eee-de251784f708">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">unspecified</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="f50f9029-3bf9-4e1a-acc0-10cc89fe87b8" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" amount="7.4530074E-10" elementaryExchangeId="017be306-b88a-4d3a-a906-b8734b72b6fb">
+        <name xml:lang="en">Carboxylic acids, unspecified</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment subcompartmentId="e47f0a6c-3be8-4027-9eee-de251784f708">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">unspecified</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="5e236925-c77b-44d6-afc3-819c12ed3d42" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="001634-04-4" amount="1.8604401E-07" elementaryExchangeId="77fd3c56-5c3e-4070-93fa-de03fa455d47">
+        <name xml:lang="en">t-Butyl methyl ether</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment subcompartmentId="963f8022-3e2e-4be9-ad4d-b3b7a2282099">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">surface water</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="5e643f6b-d61f-4a53-9407-475efc37c752" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="007782-49-2" amount="2.8753734E-07" elementaryExchangeId="62cc5e18-da24-4fb7-9f7c-1601fedba341">
+        <name xml:lang="en">Selenium</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment subcompartmentId="65f8d2a1-63ed-479c-b86c-3bcf38e86320">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">ocean</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="60233e1b-7f1e-4ce0-92c0-4a8c568ed2e2" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="022541-77-1" amount="6.0089159E-07" elementaryExchangeId="dbdc3ea8-cc2b-4dbe-82b9-e954e333281d">
+        <name xml:lang="en">Vanadium, ion</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment subcompartmentId="65f8d2a1-63ed-479c-b86c-3bcf38e86320">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">ocean</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="94cafef6-3a71-49d9-9905-bf0e9bae25e4" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="007727-37-9" amount="0.0001575334" elementaryExchangeId="77c7dcf8-1d10-4725-9f8f-bcdccaed0836">
+        <name xml:lang="en">Nitrogen, organic bound</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment subcompartmentId="65f8d2a1-63ed-479c-b86c-3bcf38e86320">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">ocean</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="45589a4f-f521-45b9-9647-1be21ec86bc7" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="007439-98-7" amount="1.9183526E-07" elementaryExchangeId="163926e2-b4cc-42bb-ba7d-401028140985">
+        <name xml:lang="en">Molybdenum</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment subcompartmentId="65f8d2a1-63ed-479c-b86c-3bcf38e86320">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">ocean</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <elementaryExchange id="99e3d169-1467-4d18-ac0f-54d753da2737" unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="001634-04-4" amount="3.2396473E-07" elementaryExchangeId="c5b4869c-f131-4a8c-911f-f252cafb2e30">
+        <name xml:lang="en">t-Butyl methyl ether</name>
+        <unitName xml:lang="en">kg</unitName>
+        <compartment subcompartmentId="65f8d2a1-63ed-479c-b86c-3bcf38e86320">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">ocean</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup></elementaryExchange>
+      <parameter parameterId="d1efa4be-e613-43fd-9d73-e8b92b39b283" variableName="fraction_CW_to_air" mathematicalRelation="(0.5*fraction_CW_OT_to_air)+(0.5*fraction_CW_R_to_air)" isCalculatedAmount="true" amount="0.3875">
+        <name xml:lang="en">fraction, cooling water, to air</name>
+        <uncertainty>
+          <lognormal meanValue="0.3875" mu="-0.95" variance="0.04" varianceWithPedigreeUncertainty="0.092025" />
+          <pedigreeMatrix reliability="4" completeness="4" temporalCorrelation="3" geographicalCorrelation="2" furtherTechnologyCorrelation="4" />
+        </uncertainty>
+        <comment xml:lang="en">Calculated value based on literature value (see comments of the other parametres present in this dataset) and expert opinion. In the case when no industry/literature data are available about the type of cooling or directly fraction, cooling water, to air specific for the process a default assumption is applied. It is assumed that the once-through cooling system is used in 50% of all cases and recirculating system is used in another 50% of all cases. </comment></parameter>
+      <parameter parameterId="606c3625-2a78-4202-87a6-16f43eec86c3" variableName="fraction_CW_CP_to_air" amount="0.032">
+        <name xml:lang="en">fraction, cooling water, cooling pond system, to air</name>
+        <uncertainty>
+          <lognormal meanValue="0.032" mu="-3.44" variance="0.04" varianceWithPedigreeUncertainty="0.0413" />
+          <pedigreeMatrix reliability="2" completeness="3" temporalCorrelation="1" geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+        </uncertainty>
+        <comment xml:lang="en">Calculated based on literature value (Scown, C.D., 2011, Water Footprint of U.S. Transportation Fuels and supplying information of the article) (Vionnet, S., Quantis Water Database - Technical Report, 2012). </comment></parameter>
+      <parameter parameterId="e952df4c-1ca5-4710-9f53-be47be9191c1" variableName="fraction_CW_R_to_air" amount="0.771">
+        <name xml:lang="en">fraction, cooling water, recirculating system, to air</name>
+        <uncertainty>
+          <lognormal meanValue="0.771" mu="-0.26" variance="0.04" varianceWithPedigreeUncertainty="0.0413" />
+          <pedigreeMatrix reliability="2" completeness="3" temporalCorrelation="1" geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+        </uncertainty>
+        <comment xml:lang="en">Calculated based on literature value (Scown, C.D., 2011, Water Footprint of U.S. Transportation Fuels and supplying information of the article) (Vionnet, S., Quantis Water Database - Technical Report, 2012). </comment></parameter>
+      <parameter parameterId="0b267c5e-0421-434c-8209-62d70a1f2f07" variableName="fraction_CW_OT_to_air" amount="0.004">
+        <name xml:lang="en">fraction, cooling water, once-through system, to air</name>
+        <uncertainty>
+          <lognormal meanValue="0.004" mu="-5.52" variance="0.04" varianceWithPedigreeUncertainty="0.0413" />
+          <pedigreeMatrix reliability="2" completeness="3" temporalCorrelation="1" geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+        </uncertainty>
+        <comment xml:lang="en">Calculated based on literature value (Scown, C.D., 2011, Water Footprint of U.S. Transportation Fuels and supplying information of the article) (Vionnet, S., Quantis Water Database - Technical Report, 2012). </comment></parameter>
+    </flowData>
+    <modellingAndValidation>
+      <representativeness systemModelId="dd7f13f5-0658-489c-a19c-f2ff8a00bdd9">
+        <systemModelName xml:lang="en">Substitution, consequential, long-term</systemModelName>
+        <samplingProcedure xml:lang="en">Literature</samplingProcedure>
+        <extrapolations xml:lang="en">see Geography and Technology This dataset has been copied from an original dataset covering the geography RER. The uncertainty has been adjusted accordingly.</extrapolations>
+      </representativeness>
+    </modellingAndValidation>
+    <administrativeInformation>
+      <dataEntryBy personId="c4597934-ecac-422c-b431-382e85fdcb83" isActiveAuthor="false" personName="[System]" personEmail="support@ecoinvent.org" />
+      <dataGeneratorAndPublication personId="d8f5bd0b-dcde-41a3-a370-4fd9f721d536" personName="Hans-Jörg Althaus" personEmail="empa@ecoinvent.org" dataPublishedIn="2" publishedSourceId="e77a52e5-4bad-4eee-b53e-5af10ebf404c" publishedSourceYear="2007" publishedSourceFirstAuthor="Werner F." isCopyrightProtected="true" accessRestrictedTo="2" companyId="bbf9cfb4-e253-4419-9d84-f206a3b64de7" companyCode="ECOINV" />
+      <fileAttributes majorRelease="3" minorRelease="0" majorRevision="89" minorRevision="0" internalSchemaVersion="2.0.10" defaultLanguage="en" creationTimestamp="2010-07-29T14:06:26" lastEditTimestamp="2013-02-25T13:56:06" fileGenerator="EcoEditor 3.2.63.9512" fileTimestamp="2013-02-25T13:56:06" contextId="de659012-50c4-4e96-b54a-fc781bf987ab">
+        <contextName xml:lang="en">ecoinvent</contextName>
+      </fileAttributes>
+    </administrativeInformation></activityDataset></ecoSpold>

--- a/tests/fixtures/v2/v2_2.spold
+++ b/tests/fixtures/v2/v2_2.spold
@@ -1,0 +1,1941 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ecoSpold xmlns="http://www.EcoInvent.org/EcoSpold02">
+  <childActivityDataset>
+    <activityDescription>
+      <activity id="ffed8e5b-8ecb-4a93-bc79-a1404afd9fcd"
+        activityNameId="8b542688-aa36-45d5-b2f0-3b15ade03700"
+        parentActivityId="dca19657-6614-4b1d-98aa-0658dd2ced39" inheritanceDepth="0" type="1"
+        specialActivityType="0" energyValues="0">
+        <activityName xml:lang="en">formic acid production, methyl formate route</activityName>
+        <synonym xml:lang="en">methanoic acid</synonym>
+        <includedActivitiesStart xml:lang="en">From the reception of methyl formate at the factory
+          gate.</includedActivitiesStart>
+        <includedActivitiesEnd xml:lang="en">This activity ends with 1 kg of formic acid, 100% af
+          the factory gate. The dataset includes the input materials, energy uses, infrastructure
+          and emissions.</includedActivitiesEnd>
+        <generalComment>
+          <text xml:lang="en" index="1">This data represents the production of 1 kg of formic acid
+            from methyl formate. Raw materials and energy consumptions are modelled with literature
+            data. The emissions are estimated. Infrastructure is included with a default value.</text>
+          <text xml:lang="en" index="2">[This dataset was already contained in the ecoinvent
+            database version 2. It was not individually updated during the transfer to ecoinvent
+            version 3. Life Cycle Impact Assessment results may still have changed, as they are
+            affected by changes in the supply chain, i.e. in other datasets. This dataset was
+            generated following the ecoinvent quality guidelines for version 2. It may have been
+            subject to central changes described in the ecoinvent version 3 change report
+            (http://www.ecoinvent.org/database/ecoinvent-version-3/reports-of-changes/), and the
+            results of the central updates were reviewed extensively. The changes added e.g.
+            consistent water flows and other information throughout the database. The documentation
+            of this dataset can be found in the ecoinvent reports of version 2, which are still
+            available via the ecoinvent website. The change report linked above covers all central
+            changes that were made during the conversion process.]</text>
+        </generalComment>
+        <tag>ConvertedDataset</tag>
+      </activity>
+      <classification classificationId="7ac1cbc6-1385-4a68-8647-ed7aa78db201">
+        <classificationSystem xml:lang="en">EcoSpold01Categories</classificationSystem>
+        <classificationValue xml:lang="en">chemicals/organics</classificationValue>
+      </classification>
+      <classification classificationId="28f738cc-bb73-48f8-b633-f83fb9bc5ddc">
+        <classificationSystem xml:lang="en">ISIC rev.4 ecoinvent</classificationSystem>
+        <classificationValue xml:lang="en">2011:Manufacture of basic chemicals</classificationValue>
+      </classification>
+      <geography geographyId="0723d252-7e2a-11de-9820-0019e336be3a">
+        <shortname xml:lang="en">RER</shortname>
+        <comment>
+          <text xml:lang="en" index="1">The inventory is modelled for Europe.</text>
+        </comment>
+      </geography>
+      <technology technologyLevel="3">
+        <comment>
+          <text xml:lang="en" index="16">To keep undesirable reesterification as low as possible,
+            the time of direct contact between methanol and formic acid must be as short as
+            possible, and separation must be carried out at the lowest possible temperature.
+            Introduction of methyl formate into the lower part of the column in which lower boiling
+            methyl formate and methanol are separated from water and formic acid, has also been
+            suggested. This largely prevents reesterification because of the excess methyl formate
+            present in the critical region of the column.</text>
+          <text xml:lang="en" index="5">In the two processes mentioned, the first stage involves
+            carbonylation of methanol in the liquid phase with carbon monoxide, in the presence of a
+            basic catalyst:
+          </text>
+          <text xml:lang="en" index="6"></text>
+          <text xml:lang="en" index="18">Formic acid is marketed in concentrations exceeding 85 wt
+            %; therefore, dehydration of the hydrolysis mixture is an important step in the
+            production of formic acid from methyl formate. For dehydration, the azeotropic point
+            must be overcome. The concentration of formic acid in the azeotropic mixture increases
+            if distillation is carried out under pressure, but the higher boiling point at high
+            pressure also increases the decomposition rate of formic acid. At the same time, the
+            selection of sufficiently corrosion-resistant materials presents considerable problems.
+            A number of entrainers have been proposed for azeotropic distillation.</text>
+          <text xml:lang="en" index="8">As a rule, the catalyst is sodium methoxide. Potassium
+            methoxide has also been proposed as a catalyst; it is more soluble in methyl formate and
+            gives a higher reaction rate. Although fairly high pressures were initially preferred,
+            carbonylation is carried out in new plants at lower pressure. Under these conditions,
+            reaction temperature and catalyst concentration must be increased to achieve acceptable
+            conversion. According to published data, ca. 4.5 MPa, 80 °C, and 2.5 wt % sodium
+            methoxide are employed. About 95 % carbon monoxide, but only about 30 % methanol, is
+            converted under these circumstances. Nearly quantitative conversion of methanol to
+            methyl formate can, nevertheless, be achieved by recycling the unreacted methanol. The
+            carbonylation of methanol is an equilibrium reaction. The reaction rate can be raised by
+            increasing the temperature, the carbon monoxide partial pressure, the catalyst
+            concentration, and the interface between gas and liquid. </text>
+          <text xml:lang="en" index="11">In the second stage, the methyl formate obtained is
+            hydrolyzed:</text>
+          <text xml:lang="en" index="3">Although the carbonylation of methanol is relatively
+            problem-free and has been carried out industrially for a long time, only recently has
+            the hydrolysis of methyl formate been developed into an economically feasible process.
+            The main problems are associated with work-up of the hydrolysis mixture. Because of the
+            unfavorable position of the equilibrium, reesterification of methanol and formic acid to
+            methyl formate occurs rapidly during the separation of unreacted methyl formate.
+            Problems also arise in the selection of sufficiently corrosion-resistant materials</text>
+          <text xml:lang="en" index="15">A two-stage hydrolysis has been suggested, in which a
+            water-soluble formamide is used in the second stage; this forms a salt-like compound
+            with formic acid. It also shifts the equilibrium in the direction of formic acid.</text>
+          <text xml:lang="en" index="17">Dehydration of the Hydrolysis Mixture</text>
+          <text xml:lang="en" index="2">Synthesis of formic acid by hydrolysis of methyl formate is
+            based on a two-stage process: in the first stage, methanol is carbonylated with carbon
+            monoxide; in the second stage, methyl formate is hydrolyzed to formic acid and methanol.
+            The methanol is returned to the first stage.</text>
+          <imageUrl index="12">https://db3.ecoinvent.org/images/2ddc19c0-905f-42c3-b14c-e68332befec9</imageUrl>
+          <text xml:lang="en" index="10">Hydrolysis of Methyl Formate</text>
+          <text xml:lang="en" index="1">The worldwide installed capacity for producing formic acid
+            was about 330 000 t/a in 1988. </text>
+          <text xml:lang="en" index="19">Reference:</text>
+          <text xml:lang="en" index="9">To synthesize methyl formate, gas mixtures with a low
+            proportion of carbon monoxide must first be concentrated. In a side reaction, sodium
+            methoxide reacts with methyl formate to form sodium formate and dimethyl ether, and
+            becomes inactivated. The substances used must be anhydrous; otherwise, sodium formate is
+            precipitated to an increasing extent. Sodium formate is considerably less soluble in
+            methyl formate than in methanol. The risk of encrustation and blockage due to
+            precipitation of sodium formate can be reduced by adding poly(ethylene glycol). The
+            carbon monoxide used must contain only a small amount of carbon dioxide; otherwise, the
+            catalytically inactive carbonate is precipitated.
+            Basic catalysts may reverse the reaction, and methyl formate decomposes into methanol
+            and carbon monoxide. Therefore, undecomposed sodium methoxide in the methyl formate must
+            be neutralized.
+          </text>
+          <text xml:lang="en" index="13">The equilibrium constant for methyl formate hydrolysis
+            depends on the water: ester ratio. With a molar ratio of 1, the constant is 0.14, but
+            with a water: methyl formate molar ratio of 15, it is 0.24. Because of the unfavorable
+            position of this equilibrium, a large excess of either water or methyl formate must be
+            used to obtain an economically worthwhile methyl formate conversion. If methyl formate
+            and water are used in a molar ratio of 1 : 1, the conversion is only 30 %, but if the
+            molar ratio of water to methyl formate is increased to 5 – 6, the conversion of methyl
+            formate rises to 60 %. However, a dilute aqueous solution of formic acid is obtained
+            this way, and excess water must be removed from the formic acid with the expenditure of
+            as little energy as possible.</text>
+          <text xml:lang="en" index="4">Carbonylation of Methanol
+          </text>
+          <text xml:lang="en" index="20">Gräfje, H., Körnig, W., Weitz, H.-M., Reiß, W.:
+            Butanediols, Butenediol, and Butynediol, Chapter 1. In: Ullmann's Encyclopedia of
+            Industrial Chemistry, Sev-enth Edition, 2004 Electronic Release (ed. Fiedler E.,
+            Grossmann G., Kersebohm D., Weiss G. and Witte C.). 7 th Electronic Release Edition.
+            WileyInterScience, New York, Online-Version under:
+            http://www.mrw.interscience.wiley.com/ueic/articles/a04_455/frame.html</text>
+          <imageUrl index="7">https://db3.ecoinvent.org/images/a0ec6e15-92c8-4d44-82bb-84e90e58b171</imageUrl>
+          <text xml:lang="en" index="14">Another way to overcome the unfavorable position of the
+            equilibrium is to hydrolyze methyl formate in the presence of a tertiary amine, e.g.,
+            1-(n-pentyl)imidazole. The base forms a salt-like compound with formic acid; therefore,
+            the concentration of free formic acid decreases and the hydrolysis equilibrium is
+            shifted in the direction of products. In a subsequent step formic acid can be distilled
+            from the base without decomposition.</text>
+        </comment>
+      </technology>
+      <timePeriod startDate="1984-01-01" endDate="2014-12-31" isDataValidForEntirePeriod="true">
+        <comment>
+          <text xml:lang="en" index="1">Time of publications</text>
+        </comment>
+      </timePeriod>
+      <macroEconomicScenario macroEconomicScenarioId="d9f57f0a-a01f-42eb-a57b-8f18d6635801">
+        <name xml:lang="en">Business-as-Usual</name>
+      </macroEconomicScenario>
+    </activityDescription>
+    <flowData>
+      <intermediateExchange id="2592e17c-df72-4446-91f5-fa1f1e0e8042"
+        unitId="487df68b-4994-4027-8fdc-a4dc298257b7" variableName="water_deionised_input"
+        casNumber="007732-18-5" amount="0.6"
+        intermediateExchangeId="360e2eb0-f81c-4e4b-ba6b-c7a690f31275"
+        activityLinkId="cd1f547f-577f-4e1b-bd23-fb73d53497eb">
+        <name xml:lang="en">water, deionised, from tap water, at user</name>
+        <unitName xml:lang="en">kg</unitName>
+        <comment>EcoSpold01Location=CH</comment>
+        <comment xml:lang="en">Literature value.</comment>
+        <uncertainty>
+          <lognormal meanValue="0.6" mu="-0.51" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Herman 1984</comment>
+        </uncertainty>
+        <property propertyId="c74c3729-e577-4081-b572-a283d2561a75" amount="0"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+        </property>
+        <property propertyId="6d9e1462-80e3-4f10-b3f4-71febd6f1168" amount="1"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">water in wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="67f102e2-9cb6-4d20-aa16-bf74d8a03326" amount="1"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="3a0af1d6-04c3-41c6-a3da-92c4f61e0eaa" amount="0"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">dry mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="6393c14b-db78-445d-a47b-c0cb866a1b25" amount="0"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, non-fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+        </property>
+        <property propertyId="a301a838-7975-4d89-9e74-8eb77ad03cd1" amount="0"
+          isDefiningValue="false" unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">carbon content on a dry matter basis (reserved; not for manual
+            entry)</comment>
+        </property>
+        <property propertyId="f2283db2-62e4-467f-b9ac-c4f45be563b4" amount="0"
+          isDefiningValue="false" unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">carbon allocation</name>
+          <unitName xml:lang="en">kg</unitName>
+          <comment xml:lang="en">carbon content per unit of product (reserved; not for manual entry)</comment>
+        </property>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="336dd4ef-cece-4c49-b412-5fe565ec8b8f"
+        unitId="980b811e-3905-4797-82a5-173f5568bc7e" amount="0"
+        intermediateExchangeId="1125e767-7b5d-442e-81d6-9b0d3e1919ac" productionVolumeAmount="0">
+        <name xml:lang="en">heat, district or industrial, natural gas</name>
+        <unitName xml:lang="en">MJ</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <uncertainty>
+          <normal meanValue="0" variance="0" varianceWithPedigreeUncertainty="0" />
+          <pedigreeMatrix reliability="1" completeness="1" temporalCorrelation="1"
+            geographicalCorrelation="1" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="87aac152-8cbe-48da-80fa-ac048384e613"
+        unitId="5b972631-34e3-4db7-a615-f6931770a0cb" amount="4E-10"
+        intermediateExchangeId="3d0fe4e0-eac9-4704-b3fd-09b8594d0fbe"
+        activityLinkId="a05ffe94-a5a7-4004-870a-f50627e2e244">
+        <name xml:lang="en">chemical factory, organics</name>
+        <unitName xml:lang="en">unit</unitName>
+        <comment>EcoSpold01Location=RER</comment>
+        <comment xml:lang="en">Estimation. This module assumes a built area of about 4.2 ha, an
+          average output of 50'000 t/a, and plant life of fifty years.
+        </comment>
+        <uncertainty>
+          <lognormal meanValue="4E-10" mu="-21.64" variance="0.27"
+            varianceWithPedigreeUncertainty="0.448" />
+          <pedigreeMatrix reliability="4" completeness="5" temporalCorrelation="5"
+            geographicalCorrelation="5" furtherTechnologyCorrelation="5" />
+          <comment xml:lang="en">Estimation</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="d8fae286-154d-4da2-9d6e-68c0df0ab462"
+        unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="630-08-0" amount="0.6144"
+        intermediateExchangeId="d349d8a1-79fb-433e-8bf4-64fbda6f657a"
+        activityLinkId="e46ee8d8-f1e0-4da6-813a-ef33b3f114bb">
+        <name xml:lang="en">carbon monoxide</name>
+        <unitName xml:lang="en">kg</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=RER</comment>
+        <uncertainty>
+          <lognormal meanValue="0.6144" mu="-0.49" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <property propertyId="a9358458-9724-4f03-b622-106eda248916" amount="0"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">water content</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">water mass/dry mass</comment>
+        </property>
+        <property propertyId="3a0af1d6-04c3-41c6-a3da-92c4f61e0eaa" amount="1"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">dry mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="6393c14b-db78-445d-a47b-c0cb866a1b25" amount="0"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, non-fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">CO. It is assumed that CO is produced from partial combustion of
+            heavy heating oil.</comment>
+        </property>
+        <property propertyId="67f102e2-9cb6-4d20-aa16-bf74d8a03326" amount="1"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="c74c3729-e577-4081-b572-a283d2561a75" amount="0.428571428571429"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">CO. It is assumed that CO is produced from partial combustion of
+            heavy heating oil.</comment>
+        </property>
+        <property propertyId="6d9e1462-80e3-4f10-b3f4-71febd6f1168" amount="0"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">water in wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="a301a838-7975-4d89-9e74-8eb77ad03cd1" amount="0.428571428571429"
+          isDefiningValue="false" unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">carbon content on a dry matter basis (reserved; not for manual
+            entry)</comment>
+        </property>
+        <property propertyId="f2283db2-62e4-467f-b9ac-c4f45be563b4" amount="0.428571428571429"
+          isDefiningValue="false" unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">carbon allocation</name>
+          <unitName xml:lang="en">kg</unitName>
+          <comment xml:lang="en">carbon content per unit of product (reserved; not for manual entry)</comment>
+        </property>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="ad13b351-1731-4020-86d6-f559b4d1c740"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d" productionVolumeAmount="0">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <normal meanValue="0" variance="0" varianceWithPedigreeUncertainty="0" />
+          <pedigreeMatrix reliability="1" completeness="1" temporalCorrelation="1"
+            geographicalCorrelation="1" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="4d141374-3fb8-4107-bbb8-ae42340152f6"
+        unitId="980b811e-3905-4797-82a5-173f5568bc7e" amount="0"
+        intermediateExchangeId="71e2f1db-a2c5-44d0-8337-dfff15be974d" productionVolumeAmount="0">
+        <name xml:lang="en">heat, district or industrial, other than natural gas</name>
+        <unitName xml:lang="en">MJ</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <uncertainty>
+          <normal meanValue="0" variance="0" varianceWithPedigreeUncertainty="0" />
+          <pedigreeMatrix reliability="1" completeness="1" temporalCorrelation="1"
+            geographicalCorrelation="1" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="7caf2882-c7af-4fe9-9ce8-d1616d08166e"
+        unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="64-18-6" amount="1"
+        intermediateExchangeId="118a9202-6b68-44aa-82b5-2c2bf5bc02cf"
+        productionVolumeAmount="256000000">
+        <name xml:lang="en">formic acid</name>
+        <unitName xml:lang="en">kg</unitName>
+        <comment xml:lang="en">Formic acid is a colorless liquid with a pungent odor, which is
+          completely miscible with water and many polar solvents but only partially miscible with
+          hydrocarbons. Formic acid has been detected in the poison or defense systems of ants,
+          bees, and other insects and also of cnidarians.
+
+          Formic acid is used primarily in dyeing, in the textile and leather industries; in rubber
+          production; and as an intermediate in the chemical and pharmaceutical industries. The use
+          of formic acid as an aid in the ensilage of green forage has increased sharply.
+
+          The worldwide production of formic acid is about 260 000 t/a in 1987 and 390 000 t/a in
+          1995.</comment>
+        <comment>EcoSpold01Location=RER</comment>
+        <property propertyId="c74c3729-e577-4081-b572-a283d2561a75" amount="0.4"
+          isDefiningValue="true" unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">CH2O</comment>
+        </property>
+        <property propertyId="a9358458-9724-4f03-b622-106eda248916" amount="0"
+          isDefiningValue="true" unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">water content</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">water mass/dry mass</comment>
+        </property>
+        <property propertyId="6d9e1462-80e3-4f10-b3f4-71febd6f1168" amount="0"
+          isDefiningValue="true" unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">water in wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="67f102e2-9cb6-4d20-aa16-bf74d8a03326" amount="1"
+          isDefiningValue="true" unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="6393c14b-db78-445d-a47b-c0cb866a1b25" amount="0"
+          isDefiningValue="true" unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, non-fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">CH2O</comment>
+        </property>
+        <property propertyId="3a0af1d6-04c3-41c6-a3da-92c4f61e0eaa" amount="1"
+          isDefiningValue="true" unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">dry mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="38f94dd1-d5aa-41b8-b182-c0c42985d9dc" amount="0.404"
+          isDefiningValue="true" unitId="7b75baf0-cbee-45e6-bf66-af119da06553">
+          <name xml:lang="en">price</name>
+          <unitName xml:lang="en">EUR2005</unitName>
+          <comment xml:lang="en">Temporary price data. Calculated as 90% of purchasers price based
+            on: 2004 import and export prices (total trades (USD) divided by total weight (kg) in
+            EU27, USA, China, Japan and India) from UN Commodity Trade Statistics Database
+            (http://data.un.org/Explorer.aspxDatabase [Accessed 2 July 2010]). Commodity: Formic
+            acid</comment>
+        </property>
+        <property propertyId="a301a838-7975-4d89-9e74-8eb77ad03cd1" amount="0.4"
+          isDefiningValue="false" unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">carbon content on a dry matter basis (reserved; not for manual
+            entry)</comment>
+        </property>
+        <property propertyId="f2283db2-62e4-467f-b9ac-c4f45be563b4" amount="0.4"
+          isDefiningValue="false" unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">carbon allocation</name>
+          <unitName xml:lang="en">kg</unitName>
+          <comment xml:lang="en">carbon content per unit of product (reserved; not for manual entry)</comment>
+        </property>
+        <productionVolumeComment xml:lang="en">unknown
+          //Comment added during dataset update://
+          Calculated with 80% capacity utilisation from 320 million kg European capacity according
+          to http://www.dfcinternational.com/files/DuniaFormicAcidSurvey15June2008.pdf</productionVolumeComment>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <outputGroup>0</outputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="161deacd-51b0-40ac-bb29-03bbcf37eded"
+        unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="000067-56-1" amount="0.04"
+        intermediateExchangeId="4a0b47d3-c643-4b67-841b-b5689787f7a1"
+        activityLinkId="8fc0a383-daac-4de7-8e40-1fee1ca4f39f">
+        <name xml:lang="en">methanol</name>
+        <unitName xml:lang="en">kg</unitName>
+        <comment>EcoSpold01Location=GLO</comment>
+        <comment xml:lang="en">Literature value.</comment>
+        <uncertainty>
+          <lognormal meanValue="0.04" mu="-3.22" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <property propertyId="a9358458-9724-4f03-b622-106eda248916" amount="0"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">water content</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">water mass/dry mass</comment>
+        </property>
+        <property propertyId="3a0af1d6-04c3-41c6-a3da-92c4f61e0eaa" amount="1"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">dry mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="c74c3729-e577-4081-b572-a283d2561a75" amount="0.375"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">CH3OH</comment>
+        </property>
+        <property propertyId="6393c14b-db78-445d-a47b-c0cb866a1b25" amount="0"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, non-fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">CH3OH</comment>
+        </property>
+        <property propertyId="6d9e1462-80e3-4f10-b3f4-71febd6f1168" amount="0"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">water in wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="67f102e2-9cb6-4d20-aa16-bf74d8a03326" amount="1"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="a301a838-7975-4d89-9e74-8eb77ad03cd1" amount="0.375"
+          isDefiningValue="false" unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">carbon content on a dry matter basis (reserved; not for manual
+            entry)</comment>
+        </property>
+        <property propertyId="f2283db2-62e4-467f-b9ac-c4f45be563b4" amount="0.375"
+          isDefiningValue="false" unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">carbon allocation</name>
+          <unitName xml:lang="en">kg</unitName>
+          <comment xml:lang="en">carbon content per unit of product (reserved; not for manual entry)</comment>
+        </property>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="6791e9b4-5f26-4511-9289-fd4038ffdc71"
+        unitId="980b811e-3905-4797-82a5-173f5568bc7e" amount="14.5211941344067"
+        intermediateExchangeId="1125e767-7b5d-442e-81d6-9b0d3e1919ac"
+        activityLinkId="9cd1a7a7-257a-46d4-b434-3b6b4a6ef9bb">
+        <name xml:lang="en">heat, district or industrial, natural gas</name>
+        <unitName xml:lang="en">MJ</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <uncertainty>
+          <lognormal meanValue="14.5211941344067" mu="2.96" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="010fbe67-c86c-42d5-98d7-fb0bb36630c1"
+        unitId="980b811e-3905-4797-82a5-173f5568bc7e" amount="0.108805865593314"
+        intermediateExchangeId="1125e767-7b5d-442e-81d6-9b0d3e1919ac"
+        activityLinkId="81689832-3b4f-4762-bfed-86cf34a156dd">
+        <name xml:lang="en">heat, district or industrial, natural gas</name>
+        <unitName xml:lang="en">MJ</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <uncertainty>
+          <lognormal meanValue="0.108805865593314" mu="2.96" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="300942c7-d2bf-451f-8d6c-b44ba9d0cb19"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.00218659508564004"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="53b0364f-3a53-49c4-bdc7-804bc21a305c">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.00218659508564004" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="3a35840b-8c9c-4ad7-9d18-1c75dfc5e3dc"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.000753743606252286"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="84b7a804-cd83-4e66-8f11-cb742b21c939">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.000753743606252286" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="096883f4-a60e-4555-a788-02a2ed6b5a29"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.0111604898781731"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="348f9761-466b-4be6-89bb-115f45c31701">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.0111604898781731" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="f1d35690-cd13-4c98-a5ba-178d5b22b733"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.00225779534197357"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="049c9371-fbd2-468e-943c-b437629ceff1">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.00225779534197357" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="2d45c55f-fa70-4af4-ab2c-082cacdb11c6"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.00524915086409765"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="b5023086-b753-4853-9f28-486bbee0ebf1">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.00524915086409765" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="9584df18-5376-4d3d-b2f2-984e9822bf9a"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.0464080522400665"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="da6465f6-dbaa-47ef-8e55-48c28e291690">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.0464080522400665" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="7165b81b-912f-4677-822e-d27d654a1749"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.00269255492889804"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="cfa2cfb7-9608-4a18-bae5-59d6fce88c89">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.00269255492889804" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="b2b497ae-8aa9-43ba-a9b8-58780cc13734"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.0115483552070057"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="a4db1dc2-e3ab-4e43-befb-54d8208bc735">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.0115483552070057" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="b84c8fd6-aaad-4770-b065-6aa22593a2f0"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.0230577177525212"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="f06c13ae-f824-42c7-9030-ec7b43641c51">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.0230577177525212" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="6a77bb97-87b2-41be-9af0-a09d351fb469"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.0100155313532324"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="13e4f9bc-8014-4284-8260-e426975f93bd">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.0100155313532324" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="73b85d97-2faf-42e7-9502-5d1cd2be1754"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.039981735256169"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="19c514e1-0b55-485c-b1c3-97c777bd9c44">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.039981735256169" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="9cba509a-4b13-435c-b5b0-4c5c97fcb829"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.00436168132405607"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="e7cc7ed4-7548-483f-b3d2-fe901425364e">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.00436168132405607" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="f2d0d356-ee2c-477a-bbbd-2ced5b463439"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.00328766539468223"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="c0d87f67-7c7c-4a2e-af31-6c28b3618e1a">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.00328766539468223" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="58caae82-c591-47a1-bcf9-7348bf4eb12a"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.000652740588823766"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="43e67309-fc28-4806-b293-d3db4312619c">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.000652740588823766" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="a32602e9-74dd-48f4-ad55-b203af10b865"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.00111034609635706"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="2a9c44c8-5169-491d-85f3-ae5475e1ddf8">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.00111034609635706" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="0d741f02-7973-4e22-a9c1-4a86feb5f036"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.00710628372622085"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="55120fba-61d4-44be-937b-c43c2566cb78">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.00710628372622085" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="bc28eb11-5104-41e2-9f4d-a8f0726fb15d"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.00508519273461547"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="4fc4c999-4a17-4745-90b8-db50647a27d0">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.00508519273461547" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="b8730c33-c499-4ac5-8b89-52119d493ddb"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.00430456652253399"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="a0c84a92-f929-40f9-ac3f-580b55990c21">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.00430456652253399" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="44c440e4-ca97-4130-ba21-b34b0146ac95"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.0014422131536222"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="cc4f560a-896c-4870-87e3-08caecc2952d">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.0014422131536222" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="c7eaf328-e35f-48b7-a223-4f0c19da938f"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.0132884241977386"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="ec9cc9f6-d053-4079-87c7-0319706c683e">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.0132884241977386" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="4c6b66c1-8bb8-4aad-ae77-a0e5fb920a66"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.00259241078066534"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="92ee5f3f-47af-4691-9dce-06cc43c548c8">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.00259241078066534" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="a006fc35-fcf2-43b1-a3b2-2144caabf083"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.00055268232751065"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="b707b8ed-20cb-4790-893e-6c77117843b9">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.00055268232751065" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="3dbf29d4-77d8-4d0e-a2b9-15077f09cc0d"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.0275456528483629"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="ce51bbe1-72f1-4ca9-aab5-5659fdf7fe0e">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.0275456528483629" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="5fd95bbe-063e-4880-9e42-c2bdd6a2b75e"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.00740018876503071"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="4dbffe07-b6c8-4f7a-acfe-7757e143c389">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.00740018876503071" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="33e3bee0-f07b-4d55-b336-393139afe96c"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.00511743811970336"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="c73ca35b-69dc-4323-b597-6eda9a448c8b">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.00511743811970336" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="5ad77e1f-bca3-42bc-bebb-03ac82049cd1"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.00520775336885909"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="833b6fe7-8c0a-481b-8de1-d39999bf95bb">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.00520775336885909" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="a6f5fbc2-72f2-4338-8fed-61c63508c66d"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.00989520377889787"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="ea22d023-a5e1-4267-90e5-4e1f3a564d7c">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.00989520377889787" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="0a8fcdb7-1f01-4b32-8728-87137e51b41b"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.0304831572719091"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="0943262d-a300-4d59-91ee-b84441e32fa2">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.0304831572719091" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="380aabed-0bb8-4a48-be3c-cb74fffb2c42"
+        unitId="77ae64fa-7e74-4252-9c3b-889c1cd20bfc" amount="0.00309467748638131"
+        intermediateExchangeId="759b89bd-3aa6-42ad-b767-5bb9ef5d331d"
+        activityLinkId="c3a19710-b8ef-4b86-8916-4abc5c942098">
+        <name xml:lang="en">electricity, medium voltage</name>
+        <unitName xml:lang="en">kWh</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <comment>EcoSpold01Location=UCTE</comment>
+        <uncertainty>
+          <lognormal meanValue="0.00309467748638131" mu="-2.02" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="4ea4ca52-5640-4764-9a90-6d86be160fc9"
+        unitId="980b811e-3905-4797-82a5-173f5568bc7e" amount="8.03082196058295"
+        intermediateExchangeId="71e2f1db-a2c5-44d0-8337-dfff15be974d"
+        activityLinkId="0a0c8069-80d0-410d-a91f-869362eeee4a">
+        <name xml:lang="en">heat, district or industrial, other than natural gas</name>
+        <unitName xml:lang="en">MJ</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <uncertainty>
+          <lognormal meanValue="8.03082196058295" mu="2.96" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <intermediateExchange id="21c980fd-cd41-4b83-86fd-532b1ae52af7"
+        unitId="980b811e-3905-4797-82a5-173f5568bc7e" amount="0.13502803941705"
+        intermediateExchangeId="71e2f1db-a2c5-44d0-8337-dfff15be974d"
+        activityLinkId="2552c0cf-ea79-4b38-a91a-1d4cd151a87e">
+        <name xml:lang="en">heat, district or industrial, other than natural gas</name>
+        <unitName xml:lang="en">MJ</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <uncertainty>
+          <lognormal meanValue="0.13502803941705" mu="2.96" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <classification classificationId="39b0f0ab-1a2f-401b-9f4d-6e39400760a4">
+          <classificationSystem xml:lang="en">By-product classification</classificationSystem>
+          <classificationValue xml:lang="en">allocatable product</classificationValue>
+        </classification>
+        <inputGroup>5</inputGroup>
+      </intermediateExchange>
+      <elementaryExchange id="719770d0-4b1e-4c44-bd9e-72c4687a6ee0"
+        unitId="487df68b-4994-4027-8fdc-a4dc298257b7" amount="0.0011"
+        elementaryExchangeId="70d467b6-115e-43c5-add2-441de9411348">
+        <name xml:lang="en">BOD5, Biological Oxygen Demand</name>
+        <unitName xml:lang="en">kg</unitName>
+        <comment xml:lang="en">Calculation. This value was calculated from the amount of methyl
+          formate in the treated waste water assuming a carbon conversion of 96% for COD. The worst
+          case scenario, BOD=COD, was used.
+
+          It is assumed that the manufacturing plant is located in an urban/industrial area and
+          consequently the emissions are categorised as emanating in a high population density area.
+          The emissions into water are assumed to be emitted into rivers.</comment>
+        <uncertainty>
+          <lognormal meanValue="0.0011" mu="-6.81" variance="0.01"
+            varianceWithPedigreeUncertainty="0.188" />
+          <pedigreeMatrix reliability="4" completeness="5" temporalCorrelation="5"
+            geographicalCorrelation="5" furtherTechnologyCorrelation="5" />
+          <comment xml:lang="en">Calculated from the water emissions</comment>
+        </uncertainty>
+        <compartment subcompartmentId="963f8022-3e2e-4be9-ad4d-b3b7a2282099">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">surface water</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup>
+      </elementaryExchange>
+      <elementaryExchange id="387f2844-5643-4a95-9a19-abcc533e32de"
+        unitId="de5b3c87-0e35-4fb0-9765-4f3ba34c99e5" variableName="water_cooling_UNO_input"
+        casNumber="007732-18-5" amount="0.3755"
+        elementaryExchangeId="fc1c42ce-a759-49fa-b987-f1ec5e503db1">
+        <name xml:lang="en">Water, cooling, unspecified natural origin</name>
+        <unitName xml:lang="en">m3</unitName>
+        <comment xml:lang="en">Literature value.</comment>
+        <uncertainty>
+          <lognormal meanValue="0.3755" mu="-0.98" variance="0.03"
+            varianceWithPedigreeUncertainty="0.0707" />
+          <pedigreeMatrix reliability="1" completeness="3" temporalCorrelation="5"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+          <comment xml:lang="en">Mc Ketta 1985</comment>
+        </uncertainty>
+        <property propertyId="a9358458-9724-4f03-b622-106eda248916" amount="9081.65213442325"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">water content</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">water mass/dry mass</comment>
+        </property>
+        <property propertyId="6393c14b-db78-445d-a47b-c0cb866a1b25" amount="0"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, non-fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+        </property>
+        <property propertyId="3a0af1d6-04c3-41c6-a3da-92c4f61e0eaa" amount="0.1101"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">dry mass</name>
+          <unitName xml:lang="en">kg</unitName>
+          <comment xml:lang="en">TDS in an average river used as approximation. That is, 110.1 mg/L
+            (The Natural Water Cycle, by UNESCO)</comment>
+        </property>
+        <property propertyId="67f102e2-9cb6-4d20-aa16-bf74d8a03326" amount="1000"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="c74c3729-e577-4081-b572-a283d2561a75" amount="0.0104328554239022"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">Tab 4.8, calculated from bicarbonate content in river (The Natural
+            Water Cycle, by UNESCO)</comment>
+        </property>
+        <property propertyId="6d9e1462-80e3-4f10-b3f4-71febd6f1168" amount="999.8899"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">water in wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="a301a838-7975-4d89-9e74-8eb77ad03cd1" amount="0.0104328554239022"
+          isDefiningValue="false" unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">carbon content on a dry matter basis (reserved; not for manual
+            entry)</comment>
+        </property>
+        <property propertyId="f2283db2-62e4-467f-b9ac-c4f45be563b4" amount="0.00114865738217163"
+          isDefiningValue="false" unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">carbon allocation</name>
+          <unitName xml:lang="en">kg</unitName>
+          <comment xml:lang="en">carbon content per unit of product (reserved; not for manual entry)</comment>
+        </property>
+        <compartment subcompartmentId="30347aef-a90b-46ba-8746-b53741aa779d">
+          <compartment xml:lang="en">natural resource</compartment>
+          <subcompartment xml:lang="en">in water</subcompartment>
+        </compartment>
+        <inputGroup>4</inputGroup>
+      </elementaryExchange>
+      <elementaryExchange id="7e483680-b3f8-4063-af73-83e8052bc1e1"
+        unitId="487df68b-4994-4027-8fdc-a4dc298257b7" amount="0.0011"
+        elementaryExchangeId="fc0b5c85-3b49-42c2-a3fd-db7e57b696e3">
+        <name xml:lang="en">COD, Chemical Oxygen Demand</name>
+        <unitName xml:lang="en">kg</unitName>
+        <comment xml:lang="en">Calculation. This data was calculated from the amount of methyl
+          formate in the treated waste water assuming a carbon conversion of 96% for COD. The worst
+          case scenario BOD=COD was used.
+
+          It is assumed that the manufacturing plants are located in an urban/industrial area and
+          consequently the emissions are categorised as emanating in a high population density area.
+          Water emissions are assumed to be emitted into rivers.
+
+        </comment>
+        <uncertainty>
+          <lognormal meanValue="0.0011" mu="-6.81" variance="0.01"
+            varianceWithPedigreeUncertainty="0.188" />
+          <pedigreeMatrix reliability="4" completeness="5" temporalCorrelation="5"
+            geographicalCorrelation="5" furtherTechnologyCorrelation="5" />
+          <comment xml:lang="en">Calculated from the water emissions</comment>
+        </uncertainty>
+        <compartment subcompartmentId="963f8022-3e2e-4be9-ad4d-b3b7a2282099">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">surface water</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup>
+      </elementaryExchange>
+      <elementaryExchange id="7df2b96c-031b-4a48-a387-7820298c046e"
+        unitId="487df68b-4994-4027-8fdc-a4dc298257b7" amount="0.00042"
+        elementaryExchangeId="f65558fb-61a1-4e48-b4f2-60d62f14b085">
+        <name xml:lang="en">TOC, Total Organic Carbon</name>
+        <unitName xml:lang="en">kg</unitName>
+        <comment xml:lang="en">Calculation. This data was calculated from the amount of methyl
+          formate in the treated waste water assuming a carbon conversion of 96% for COD. The worst
+          case scenario TOC=DOC was used.
+
+          It is assumed that the manufacturing plants are located in an urban/industrial area and
+          consequently the emissions are categorised as emanating in a high population density area.
+          Water emissions are assumed to be emitted into rivers.
+
+        </comment>
+        <uncertainty>
+          <lognormal meanValue="0.00042" mu="-7.78" variance="0.01"
+            varianceWithPedigreeUncertainty="0.188" />
+          <pedigreeMatrix reliability="4" completeness="5" temporalCorrelation="5"
+            geographicalCorrelation="5" furtherTechnologyCorrelation="5" />
+          <comment xml:lang="en">Calculated from the water emissions</comment>
+        </uncertainty>
+        <compartment subcompartmentId="963f8022-3e2e-4be9-ad4d-b3b7a2282099">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">surface water</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup>
+      </elementaryExchange>
+      <elementaryExchange id="2f5d60a7-7736-40f7-9767-f50a2a46cbf7"
+        unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="000124-38-9" amount="0.013913"
+        elementaryExchangeId="f9749677-9c9f-4678-ab55-c607dfdc2cb9">
+        <name xml:lang="en">Carbon dioxide, fossil</name>
+        <unitName xml:lang="en">kg</unitName>
+        <comment xml:lang="en">Estimation. The carbon contained in the removed methyl formate during
+          waste water treatment was accounted for as CO2 emissions to air.
+
+          Air emissions occurring from the purge vent, the distillation vent and fugitive emission
+          sources were estimated to 0.2% of the raw material input.
+
+          It is assumed that the manufacturing plants are located in an urban/industrial area and
+          consequently the emissions are categorised as emanating in a high population density area.
+
+
+        </comment>
+        <uncertainty>
+          <lognormal meanValue="0.013913" mu="-4.27" varianceWithPedigreeUncertainty="0.02" />
+          <pedigreeMatrix reliability="4" completeness="5" temporalCorrelation="5"
+            geographicalCorrelation="5" furtherTechnologyCorrelation="5" />
+          <comment xml:lang="en">Calculated from the water treatment</comment>
+        </uncertainty>
+        <property propertyId="3a0af1d6-04c3-41c6-a3da-92c4f61e0eaa" amount="1"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">dry mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="67f102e2-9cb6-4d20-aa16-bf74d8a03326" amount="1"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="a9358458-9724-4f03-b622-106eda248916" amount="0"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">water content</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">water mass/dry mass</comment>
+        </property>
+        <property propertyId="c74c3729-e577-4081-b572-a283d2561a75" amount="0.272916486782489"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+        </property>
+        <property propertyId="6393c14b-db78-445d-a47b-c0cb866a1b25" amount="0"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, non-fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+        </property>
+        <property propertyId="6d9e1462-80e3-4f10-b3f4-71febd6f1168" amount="0"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">water in wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="a301a838-7975-4d89-9e74-8eb77ad03cd1" amount="0.272916486782489"
+          isDefiningValue="false" unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">carbon content on a dry matter basis (reserved; not for manual
+            entry)</comment>
+        </property>
+        <property propertyId="f2283db2-62e4-467f-b9ac-c4f45be563b4" amount="0.272916486782489"
+          isDefiningValue="false" unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">carbon allocation</name>
+          <unitName xml:lang="en">kg</unitName>
+          <comment xml:lang="en">carbon content per unit of product (reserved; not for manual entry)</comment>
+        </property>
+        <compartment subcompartmentId="e8d7772c-55ca-4dd7-b605-fee5ae764578">
+          <compartment xml:lang="en">air</compartment>
+          <subcompartment xml:lang="en">urban air close to ground</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup>
+      </elementaryExchange>
+      <elementaryExchange id="f8833dcb-107e-4c6e-b7af-725a8e144140"
+        unitId="de5b3c87-0e35-4fb0-9765-4f3ba34c99e5" variableName="water_to_water_unspecified"
+        casNumber="007732-18-5" amount="0.23047075" isCalculatedAmount="true"
+        mathematicalRelation="(water_deionised_input/1000)*(1-fraction_WDI_to_air)+water_cooling_UNO_input*(1-fraction_CW_to_air)"
+        elementaryExchangeId="2404b41a-2eed-4e9d-8ab6-783946fdf5d6">
+        <name xml:lang="en">Water</name>
+        <unitName xml:lang="en">m3</unitName>
+        <comment xml:lang="en">Calculated value based on literature values and expert opinion. See
+          comments in the parametres' comment field.</comment>
+        <uncertainty>
+          <lognormal meanValue="0.23047075" mu="-1.47" variance="0.04"
+            varianceWithPedigreeUncertainty="0.0487" />
+          <pedigreeMatrix reliability="2" completeness="2" temporalCorrelation="4"
+            geographicalCorrelation="1" furtherTechnologyCorrelation="1" />
+        </uncertainty>
+        <property propertyId="1f45c101-983d-43ff-a576-9601b15e0c65"
+          variableName="fraction_origin_unspecified_Ww" amount="0.997930323045332"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">fraction, origin: unspecified</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">This property represent the fraction of the amount of the exchange
+            which origin is unspecified. It can be either salt or fresh water.</comment>
+        </property>
+        <property propertyId="ed9ccf89-0acb-4097-8f74-867ed82f5fd0"
+          variableName="fraction_origin_salt_water_Ww" amount="0"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">fraction, origin: salt water</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">This property represent the fraction of the amount of the exchange
+            which origin is salt water.</comment>
+        </property>
+        <property propertyId="d2efbebc-9ec8-4ce3-aea4-f4353094f458"
+          variableName="fraction_origin_fresh_water_Ww" amount="0.00206967695466778"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">fraction, origin: fresh water</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">This property represent the fraction of the amount of the exchange
+            which origin is fresh water.</comment>
+        </property>
+        <property propertyId="67f102e2-9cb6-4d20-aa16-bf74d8a03326" variableName="WM" amount="1000"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="6393c14b-db78-445d-a47b-c0cb866a1b25"
+          variableName="C_content_non_fossil" amount="0"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, non-fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">biogene carbon content on a dry matter basis</comment>
+        </property>
+        <property propertyId="6d9e1462-80e3-4f10-b3f4-71febd6f1168" variableName="WWM" amount="1000"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">water in wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+          <comment xml:lang="en">water content on a wet matter basis</comment>
+        </property>
+        <property propertyId="3a0af1d6-04c3-41c6-a3da-92c4f61e0eaa" variableName="DM" amount="0"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">dry mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="c74c3729-e577-4081-b572-a283d2561a75" variableName="C_content_fossil"
+          amount="0" unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">fossil carbon content on a dry matter basis</comment>
+        </property>
+        <property propertyId="a301a838-7975-4d89-9e74-8eb77ad03cd1" amount="0"
+          isDefiningValue="false" unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">carbon content on a dry matter basis (reserved; not for manual
+            entry)</comment>
+        </property>
+        <property propertyId="f2283db2-62e4-467f-b9ac-c4f45be563b4" amount="0"
+          isDefiningValue="false" unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">carbon allocation</name>
+          <unitName xml:lang="en">kg</unitName>
+          <comment xml:lang="en">carbon content per unit of product (reserved; not for manual entry)</comment>
+        </property>
+        <compartment subcompartmentId="e47f0a6c-3be8-4027-9eee-de251784f708">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">unspecified</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup>
+      </elementaryExchange>
+      <elementaryExchange id="47a0555e-67ec-46b4-ac11-d09433e8765b"
+        unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="000107-31-3" amount="0.001054"
+        elementaryExchangeId="af3b0f01-3f06-46c7-a3b7-66bfec083264">
+        <name xml:lang="en">Methyl formate</name>
+        <unitName xml:lang="en">kg</unitName>
+        <comment xml:lang="en">Estimation. The water emissions were estimated to 0.8% of the
+          intermediate methyl formate. The carbon contained in the removed methyl formate during
+          waste water treatment was accounted for as CO2 emissions to air.
+
+          It is assumed that the manufacturing plants are located in an urban/industrial area and
+          consequently the emissions are categorised as emanating in a high population density area.
+          Water emissions are assumed to be emitted into rivers.
+        </comment>
+        <uncertainty>
+          <lognormal meanValue="0.001054" mu="-6.86" varianceWithPedigreeUncertainty="0.02" />
+          <pedigreeMatrix reliability="4" completeness="5" temporalCorrelation="5"
+            geographicalCorrelation="5" furtherTechnologyCorrelation="5" />
+          <comment xml:lang="en">Estimation</comment>
+        </uncertainty>
+        <property propertyId="6d9e1462-80e3-4f10-b3f4-71febd6f1168" amount="0"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">water in wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="67f102e2-9cb6-4d20-aa16-bf74d8a03326" amount="1"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="a9358458-9724-4f03-b622-106eda248916" amount="0"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">water content</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">water mass/dry mass</comment>
+        </property>
+        <property propertyId="6393c14b-db78-445d-a47b-c0cb866a1b25" amount="0"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, non-fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+        </property>
+        <property propertyId="c74c3729-e577-4081-b572-a283d2561a75" amount="0.400016252429538"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+        </property>
+        <property propertyId="3a0af1d6-04c3-41c6-a3da-92c4f61e0eaa" amount="1"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">dry mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="a301a838-7975-4d89-9e74-8eb77ad03cd1" amount="0.400016252429538"
+          isDefiningValue="false" unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">carbon content on a dry matter basis (reserved; not for manual
+            entry)</comment>
+        </property>
+        <property propertyId="f2283db2-62e4-467f-b9ac-c4f45be563b4" amount="0.400016252429538"
+          isDefiningValue="false" unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">carbon allocation</name>
+          <unitName xml:lang="en">kg</unitName>
+          <comment xml:lang="en">carbon content per unit of product (reserved; not for manual entry)</comment>
+        </property>
+        <compartment subcompartmentId="963f8022-3e2e-4be9-ad4d-b3b7a2282099">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">surface water</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup>
+      </elementaryExchange>
+      <elementaryExchange id="b4a9900e-84a4-437d-a0f5-d7fe1e9bc0fb"
+        unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="000630-08-0" amount="0.006144"
+        elementaryExchangeId="6edcc2df-88a3-48e1-83d8-ffc38d31c35b">
+        <name xml:lang="en">Carbon monoxide, fossil</name>
+        <unitName xml:lang="en">kg</unitName>
+        <comment xml:lang="en">Estimation. Air emissions occurring from the purge vent, the
+          distillation vent and fugitive emission sources were estimated to 0.2% of the raw material
+          input.
+
+          It is assumed that the manufacturing plants are located in an urban/industrial area and
+          consequently the emissions are categorised as emanating in a high population density area.
+
+
+        </comment>
+        <uncertainty>
+          <lognormal meanValue="0.006144" mu="-5.09" variance="0.62"
+            varianceWithPedigreeUncertainty="0.798" />
+          <pedigreeMatrix reliability="4" completeness="5" temporalCorrelation="5"
+            geographicalCorrelation="5" furtherTechnologyCorrelation="5" />
+          <comment xml:lang="en">Estimation</comment>
+        </uncertainty>
+        <property propertyId="c74c3729-e577-4081-b572-a283d2561a75" amount="0.428805015280039"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+        </property>
+        <property propertyId="6d9e1462-80e3-4f10-b3f4-71febd6f1168" amount="0"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">water in wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="3a0af1d6-04c3-41c6-a3da-92c4f61e0eaa" amount="1"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">dry mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="67f102e2-9cb6-4d20-aa16-bf74d8a03326" amount="1"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="6393c14b-db78-445d-a47b-c0cb866a1b25" amount="0"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, non-fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+        </property>
+        <property propertyId="a9358458-9724-4f03-b622-106eda248916" amount="0"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">water content</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">water mass/dry mass</comment>
+        </property>
+        <property propertyId="a301a838-7975-4d89-9e74-8eb77ad03cd1" amount="0.428805015280039"
+          isDefiningValue="false" unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">carbon content on a dry matter basis (reserved; not for manual
+            entry)</comment>
+        </property>
+        <property propertyId="f2283db2-62e4-467f-b9ac-c4f45be563b4" amount="0.428805015280039"
+          isDefiningValue="false" unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">carbon allocation</name>
+          <unitName xml:lang="en">kg</unitName>
+          <comment xml:lang="en">carbon content per unit of product (reserved; not for manual entry)</comment>
+        </property>
+        <compartment subcompartmentId="e8d7772c-55ca-4dd7-b605-fee5ae764578">
+          <compartment xml:lang="en">air</compartment>
+          <subcompartment xml:lang="en">urban air close to ground</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup>
+      </elementaryExchange>
+      <elementaryExchange id="8e2558c7-1770-44b7-a251-a2d19b96c5ea"
+        unitId="de5b3c87-0e35-4fb0-9765-4f3ba34c99e5" variableName="water_to_air_unspecified"
+        casNumber="007732-18-5" amount="0.14562925" isCalculatedAmount="true"
+        mathematicalRelation="(water_deionised_input/1000*fraction_WDI_to_air)+(water_cooling_UNO_input*fraction_CW_to_air)"
+        elementaryExchangeId="075e433b-4be4-448e-9510-9a5029c1ce94">
+        <name xml:lang="en">Water</name>
+        <unitName xml:lang="en">m3</unitName>
+        <comment xml:lang="en">Calculated value based on literature values and expert opinion. See
+          comments in the parametres' comment field.</comment>
+        <uncertainty>
+          <lognormal meanValue="0.14562925" mu="-1.93" variance="0.04"
+            varianceWithPedigreeUncertainty="0.0487" />
+          <pedigreeMatrix reliability="2" completeness="2" temporalCorrelation="4"
+            geographicalCorrelation="1" furtherTechnologyCorrelation="1" />
+        </uncertainty>
+        <property propertyId="1f45c101-983d-43ff-a576-9601b15e0c65"
+          variableName="fraction_origin_unspecified" amount="0.999155389456445"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">fraction, origin: unspecified</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">This property represent the fraction of the amount of the exchange
+            which origin is unspecified. It can be either salt or fresh water.</comment>
+        </property>
+        <property propertyId="d2efbebc-9ec8-4ce3-aea4-f4353094f458"
+          variableName="fraction_origin_fresh_water" amount="0.000844610543554952"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">fraction, origin: fresh water</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">This property represent the fraction of the amount of the exchange
+            which origin is fresh water.</comment>
+        </property>
+        <property propertyId="ed9ccf89-0acb-4097-8f74-867ed82f5fd0"
+          variableName="fraction_origin_salt_water" amount="0"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">fraction, origin: salt water</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">This property represent the fraction of the amount of the exchange
+            which origin is salt water.</comment>
+        </property>
+        <property propertyId="67f102e2-9cb6-4d20-aa16-bf74d8a03326" amount="1000"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="3a0af1d6-04c3-41c6-a3da-92c4f61e0eaa" amount="0"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">dry mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="6393c14b-db78-445d-a47b-c0cb866a1b25" amount="0"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, non-fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">biogene carbon content on a dry matter basis</comment>
+        </property>
+        <property propertyId="6d9e1462-80e3-4f10-b3f4-71febd6f1168" amount="1000"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">water in wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+          <comment xml:lang="en">water content on a wet matter basis</comment>
+        </property>
+        <property propertyId="c74c3729-e577-4081-b572-a283d2561a75" amount="0"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">fossil carbon content on a dry matter basis</comment>
+        </property>
+        <property propertyId="a301a838-7975-4d89-9e74-8eb77ad03cd1" amount="0"
+          isDefiningValue="false" unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">carbon content on a dry matter basis (reserved; not for manual
+            entry)</comment>
+        </property>
+        <property propertyId="f2283db2-62e4-467f-b9ac-c4f45be563b4" amount="0"
+          isDefiningValue="false" unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">carbon allocation</name>
+          <unitName xml:lang="en">kg</unitName>
+          <comment xml:lang="en">carbon content per unit of product (reserved; not for manual entry)</comment>
+        </property>
+        <compartment subcompartmentId="7011f0aa-f5f9-4901-8c10-884ad8296812">
+          <compartment xml:lang="en">air</compartment>
+          <subcompartment xml:lang="en">unspecified</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup>
+      </elementaryExchange>
+      <elementaryExchange id="39d0d488-592d-4ff1-9074-e34799b79979"
+        unitId="487df68b-4994-4027-8fdc-a4dc298257b7" casNumber="000107-31-3" amount="0.00264"
+        elementaryExchangeId="a71b27f2-3bcb-4bcc-a0c6-b6a123f0b42e">
+        <name xml:lang="en">Methyl formate</name>
+        <unitName xml:lang="en">kg</unitName>
+        <comment xml:lang="en">Estimation. Air emissions occurring from the purge vent, the
+          distillation vent and fugitive emission sources were estimated to 0.2% of the raw material
+          input.
+
+          It is assumed that the manufacturing plants are located in an urban/industrial area and
+          consequently the emissions are categorised as emanating in a high population density area.
+
+        </comment>
+        <uncertainty>
+          <lognormal meanValue="0.00264" mu="-5.94" varianceWithPedigreeUncertainty="0.02" />
+          <pedigreeMatrix reliability="4" completeness="5" temporalCorrelation="5"
+            geographicalCorrelation="5" furtherTechnologyCorrelation="5" />
+          <comment xml:lang="en">Estimation</comment>
+        </uncertainty>
+        <property propertyId="6393c14b-db78-445d-a47b-c0cb866a1b25" amount="0"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, non-fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+        </property>
+        <property propertyId="67f102e2-9cb6-4d20-aa16-bf74d8a03326" amount="1"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="6d9e1462-80e3-4f10-b3f4-71febd6f1168" amount="0"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">water in wet mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="3a0af1d6-04c3-41c6-a3da-92c4f61e0eaa" amount="1"
+          unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">dry mass</name>
+          <unitName xml:lang="en">kg</unitName>
+        </property>
+        <property propertyId="a9358458-9724-4f03-b622-106eda248916" amount="0"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">water content</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">water mass/dry mass</comment>
+        </property>
+        <property propertyId="c74c3729-e577-4081-b572-a283d2561a75" amount="0.400016252429538"
+          unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content, fossil</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+        </property>
+        <property propertyId="a301a838-7975-4d89-9e74-8eb77ad03cd1" amount="0.400016252429538"
+          isDefiningValue="false" unitId="577e242a-461f-44a7-922c-d8e1c3d2bf45">
+          <name xml:lang="en">carbon content</name>
+          <unitName xml:lang="en">dimensionless</unitName>
+          <comment xml:lang="en">carbon content on a dry matter basis (reserved; not for manual
+            entry)</comment>
+        </property>
+        <property propertyId="f2283db2-62e4-467f-b9ac-c4f45be563b4" amount="0.400016252429538"
+          isDefiningValue="false" unitId="487df68b-4994-4027-8fdc-a4dc298257b7">
+          <name xml:lang="en">carbon allocation</name>
+          <unitName xml:lang="en">kg</unitName>
+          <comment xml:lang="en">carbon content per unit of product (reserved; not for manual entry)</comment>
+        </property>
+        <compartment subcompartmentId="e8d7772c-55ca-4dd7-b605-fee5ae764578">
+          <compartment xml:lang="en">air</compartment>
+          <subcompartment xml:lang="en">urban air close to ground</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup>
+      </elementaryExchange>
+      <elementaryExchange id="2d4d37f5-e0b7-4e4a-9c31-a7c51c886cbf"
+        unitId="487df68b-4994-4027-8fdc-a4dc298257b7" amount="0.00042"
+        elementaryExchangeId="960c0f37-f34c-4fc1-b77c-22d8b35fd8d5">
+        <name xml:lang="en">DOC, Dissolved Organic Carbon</name>
+        <unitName xml:lang="en">kg</unitName>
+        <comment xml:lang="en">Calculation. This data was calculated from the amount of methyl
+          formate in the treated waste water assuming a carbon conversion of 96% for COD. The worst
+          case scenario TOC=DOC was used.
+
+          It is assumed that the manufacturing plants are located in an urban/industrial area and
+          consequently the emissions are categorised as emanating in a high population density area.
+          Water emissions are assumed to be emitted into rivers.
+
+        </comment>
+        <uncertainty>
+          <lognormal meanValue="0.00042" mu="-7.78" variance="0.01"
+            varianceWithPedigreeUncertainty="0.188" />
+          <pedigreeMatrix reliability="4" completeness="5" temporalCorrelation="5"
+            geographicalCorrelation="5" furtherTechnologyCorrelation="5" />
+          <comment xml:lang="en">Calculated from the water emissions</comment>
+        </uncertainty>
+        <compartment subcompartmentId="963f8022-3e2e-4be9-ad4d-b3b7a2282099">
+          <compartment xml:lang="en">water</compartment>
+          <subcompartment xml:lang="en">surface water</subcompartment>
+        </compartment>
+        <outputGroup>4</outputGroup>
+      </elementaryExchange>
+      <parameter parameterId="e952df4c-1ca5-4710-9f53-be47be9191c1"
+        variableName="fraction_CW_R_to_air" amount="0.771">
+        <name xml:lang="en">fraction, cooling water, recirculating system, to air</name>
+        <uncertainty>
+          <lognormal meanValue="0.771" mu="-0.26" variance="0.04"
+            varianceWithPedigreeUncertainty="0.0413" />
+          <pedigreeMatrix reliability="2" completeness="3" temporalCorrelation="1"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+        </uncertainty>
+        <comment xml:lang="en">Calculated based on literature value (Scown, C.D., 2011, Water
+          Footprint of U.S. Transportation Fuels and supplying information of the article) (Vionnet,
+          S., Quantis Water Database - Technical Report, 2012). </comment>
+      </parameter>
+      <parameter parameterId="ca04da6b-a4e4-4172-8be4-0ad990e2e549"
+        variableName="fraction_WDI_to_air" mathematicalRelation="fraction_PW_to_air"
+        isCalculatedAmount="true" amount="0.205">
+        <name xml:lang="en">fraction, water, deionised, to air</name>
+        <uncertainty>
+          <lognormal meanValue="0.205" mu="-1.58" variance="0.04"
+            varianceWithPedigreeUncertainty="0.092025" />
+          <pedigreeMatrix reliability="4" completeness="4" temporalCorrelation="3"
+            geographicalCorrelation="2" furtherTechnologyCorrelation="4" />
+        </uncertainty>
+        <comment xml:lang="en">Calculated value. See comment in the other parametres present in this
+          dataset. Deionised water is considered to be always used as process water, thus process
+          water fractions to air are applied to all deionised water input flows to calculate the
+          amount of water consumed in the processes.</comment>
+      </parameter>
+      <parameter parameterId="daadf2d4-7bbb-4f69-8ab5-58df4c1685eb"
+        variableName="fraction_PW_to_air" amount="0.205">
+        <name xml:lang="en">fraction, process water, to air</name>
+        <unitName xml:lang="en">dimensionless</unitName>
+        <uncertainty>
+          <lognormal meanValue="0.205" mu="-1.58" variance="0.04"
+            varianceWithPedigreeUncertainty="0.092025" />
+          <pedigreeMatrix reliability="4" completeness="4" temporalCorrelation="3"
+            geographicalCorrelation="2" furtherTechnologyCorrelation="4" />
+        </uncertainty>
+        <comment xml:lang="en">Literature value (Statistics Canada, 2007 &amp; Shaffer, K.H., 2008,
+          Consumptive water use in the Great Lakes Basin, USGS) (Vionnet, S., Quantis Water Database
+          - Technical Report, 2012).</comment>
+      </parameter>
+      <parameter parameterId="606c3625-2a78-4202-87a6-16f43eec86c3"
+        variableName="fraction_CW_CP_to_air" amount="0.032">
+        <name xml:lang="en">fraction, cooling water, cooling pond system, to air</name>
+        <uncertainty>
+          <lognormal meanValue="0.032" mu="-3.44" variance="0.04"
+            varianceWithPedigreeUncertainty="0.0413" />
+          <pedigreeMatrix reliability="2" completeness="3" temporalCorrelation="1"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+        </uncertainty>
+        <comment xml:lang="en">Calculated based on literature value (Scown, C.D., 2011, Water
+          Footprint of U.S. Transportation Fuels and supplying information of the article) (Vionnet,
+          S., Quantis Water Database - Technical Report, 2012). </comment>
+      </parameter>
+      <parameter parameterId="0b267c5e-0421-434c-8209-62d70a1f2f07"
+        variableName="fraction_CW_OT_to_air" amount="0.004">
+        <name xml:lang="en">fraction, cooling water, once-through system, to air</name>
+        <uncertainty>
+          <lognormal meanValue="0.004" mu="-5.52" variance="0.04"
+            varianceWithPedigreeUncertainty="0.0413" />
+          <pedigreeMatrix reliability="2" completeness="3" temporalCorrelation="1"
+            geographicalCorrelation="3" furtherTechnologyCorrelation="1" />
+        </uncertainty>
+        <comment xml:lang="en">Calculated based on literature value (Scown, C.D., 2011, Water
+          Footprint of U.S. Transportation Fuels and supplying information of the article) (Vionnet,
+          S., Quantis Water Database - Technical Report, 2012). </comment>
+      </parameter>
+      <parameter parameterId="d1efa4be-e613-43fd-9d73-e8b92b39b283"
+        variableName="fraction_CW_to_air"
+        mathematicalRelation="(0.5*fraction_CW_OT_to_air)+(0.5*fraction_CW_R_to_air)"
+        isCalculatedAmount="true" amount="0.3875">
+        <name xml:lang="en">fraction, cooling water, to air</name>
+        <uncertainty>
+          <lognormal meanValue="0.3875" mu="-0.95" variance="0.04"
+            varianceWithPedigreeUncertainty="0.092025" />
+          <pedigreeMatrix reliability="4" completeness="4" temporalCorrelation="3"
+            geographicalCorrelation="2" furtherTechnologyCorrelation="4" />
+        </uncertainty>
+        <comment xml:lang="en">Calculated value based on literature value (see comments of the other
+          parametres present in this dataset) and expert opinion. In the case when no
+          industry/literature data are available about the type of cooling or directly fraction,
+          cooling water, to air specific for the process a default assumption is applied. It is
+          assumed that the once-through cooling system is used in 50% of all cases and recirculating
+          system is used in another 50% of all cases. </comment>
+      </parameter>
+    </flowData>
+    <modellingAndValidation>
+      <representativeness percent="100" systemModelId="06590a66-662a-4885-8494-ad0cf410f956">
+        <systemModelName xml:lang="en">Allocation, ecoinvent default</systemModelName>
+        <samplingProcedure xml:lang="en">Literature data</samplingProcedure>
+        <extrapolations xml:lang="en">This dataset has been extrapolated from year 2006 to the year
+          of the calculation (2014). The uncertainty has been adjusted accordingly.</extrapolations>
+      </representativeness>
+    </modellingAndValidation>
+    <administrativeInformation>
+      <dataEntryBy personId="4e412379-4901-477d-bbc1-3e2797ab9350" isActiveAuthor="false"
+        personName="personName" personEmail="personEmail@domain.com" />
+      <dataGeneratorAndPublication personId="4e412379-4901-477d-bbc1-3e2797ab9350"
+        personName="personName" personEmail="personEmail@domain.com" dataPublishedIn="2"
+        publishedSourceId="71272329-1b17-415b-9f9b-299ebfbce109" publishedSourceYear="2007"
+        publishedSourceFirstAuthor="Sutter, J." isCopyrightProtected="true" pageNumbers="solvents"
+        accessRestrictedTo="1" />
+      <fileAttributes majorRelease="3" minorRelease="0" majorRevision="37" minorRevision="0"
+        internalSchemaVersion="2.0.10" defaultLanguage="en" creationTimestamp="2010-07-28T18:41:06"
+        lastEditTimestamp="2011-09-22T18:30:49" fileGenerator="EcoEditor 2.0.43.6348"
+        fileTimestamp="2011-09-22T18:30:49" contextId="de659012-50c4-4e96-b54a-fc781bf987ab">
+        <contextName xml:lang="en">ecoinvent</contextName>
+      </fileAttributes>
+    </administrativeInformation>
+  </childActivityDataset>
+</ecoSpold>

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -91,10 +91,10 @@ def test_save_file(tmpdir) -> None:
             assert translatedOutput == translatedInput
 
 
-def test_save_file_defaults(tmpdir) -> None:
+def test_save_file_defaults(tmpdir, fixtures_dir) -> None:
     """It saves read file correctly."""
-    inputPath = "data/v1/v1_1.xml"
-    expectedOutputPath = "data/tests/v1_1_defaults.xml"
+    inputPath = fixtures_dir / "v1" / "v1_1.xml"
+    expectedOutputPath = fixtures_dir / "v1" / "v1_1_defaults.xml"
     metaInformation = parse_file_v1(inputPath)
     outputPath = os.path.join(tmpdir, os.urandom(24).hex())
     save_ecospold_file(metaInformation, outputPath, fill_defaults=True)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -49,7 +49,7 @@ def test_set_attribute_list_success(process_information: ProcessInformation) -> 
 
 def test_set_element_text_success(process_information: ProcessInformation) -> None:
     "It sets attribute correctly."
-    startDate = date(2000, 1, 1)
+    startDate = date(1970, 1, 1)
     process_information.timePeriod.startDate = startDate
 
     assert process_information.timePeriod.startDate == startDate


### PR DESCRIPTION
The current handling of start and end dates was... very creative. This is better:

- It doesn't assume that `endDate` is present just because `startDate` is.
- It can handle inputs and outputs of dates >= day 10 in the month
- It has tests for most (all?) possible combinations
- It uses builtin functionality for date handling
- It doesn't default to January 1st for end dates, but correctly finds the last day and month as needed
- It checks that start < end
- It puts tests fixtures in the tests directory